### PR TITLE
Update volatility regime splits and stress evaluation coverage

### DIFF
--- a/configs/data/regimes.yaml
+++ b/configs/data/regimes.yaml
@@ -1,5 +1,5 @@
 name: volatility_regimes
-train_environments: [low, medium, high]
+train_environments: [low, medium]
 val_environment: high
 test_environment: crisis
 additional_stress: [jump, liquidity]

--- a/src/hirm_experiment/algorithms/groupdro.py
+++ b/src/hirm_experiment/algorithms/groupdro.py
@@ -18,10 +18,12 @@ class GroupDROAlgorithm(Algorithm):
         eta: float = 0.1,
     ) -> None:
         super().__init__("groupdro", feature_builder, device)
+        if not env_names:
+            raise ValueError("GroupDROAlgorithm requires at least one training environment.")
         self.eta = eta
-        self.env_order = env_names
-        weights = torch.ones(len(env_names), device=device) / len(env_names)
-        self.weights = weights
+        self.env_order = list(env_names)
+        weights = torch.ones(len(self.env_order), device=device, dtype=torch.float32)
+        self.weights = weights / weights.sum()
 
     def compute_loss(
         self,

--- a/src/hirm_experiment/data/dataset.py
+++ b/src/hirm_experiment/data/dataset.py
@@ -114,9 +114,17 @@ class VolatilityRegimeDataModule:
         self.device = device
         self.simulator = build_simulator_from_config(config, config["episode_length"])
         rng = np.random.default_rng(seed)
-        self.train_envs = list(config["train_environments"])
-        self.val_envs = [config["val_environment"]]
-        self.test_envs = [config["test_environment"]]
+
+        train_envs = list(config.get("train_environments", []))
+        if not train_envs:
+            raise ValueError("VolatilityRegimeDataModule requires at least one training environment.")
+        self.train_envs = train_envs
+
+        val_env = config.get("val_environment")
+        self.val_envs = [val_env] if val_env else []
+
+        test_env = config.get("test_environment")
+        self.test_envs = [test_env] if test_env else []
         self.additional_stress = list(config.get("additional_stress", []))
         self.datasets: Dict[str, RegimeDataset] = {}
         self.val_datasets: Dict[str, RegimeDataset] = {}
@@ -176,10 +184,18 @@ class VolatilityRegimeDataModule:
         return stats
 
     def sample_train_batches(self, batch_size: int) -> Dict[str, EpisodeBatch]:
-        per_env = max(batch_size // len(self.train_envs), 1)
+        if not self.train_envs:
+            raise ValueError("No training environments are available for sampling.")
+        env_count = len(self.train_envs)
+        base = batch_size // env_count
+        remainder = batch_size % env_count
         batches: Dict[str, EpisodeBatch] = {}
-        for env in self.train_envs:
-            batches[env] = self.datasets[env].sample(per_env, self.device)
+        for idx, env in enumerate(self.train_envs):
+            extra = 1 if idx < remainder else 0
+            env_batch = base + extra
+            if env_batch <= 0:
+                env_batch = 1
+            batches[env] = self.datasets[env].sample(env_batch, self.device)
         return batches
 
     def sample_validation(self, env: Optional[str] = None) -> Dict[str, EpisodeBatch]:

--- a/src/hirm_experiment/training/engine.py
+++ b/src/hirm_experiment/training/engine.py
@@ -116,14 +116,14 @@ class TrainingEngine:
                 for key, value in metrics.items():
                     eval_logs[f"val/{env}/{key}"] = value
             test_env = self.data_cfg.get("test_environment")
-            if test_env:
-                test_dataset = self.data_module.test_sets().get(test_env)
-                if test_dataset is not None:
-                    batch = test_dataset.full(self.device)
-                    outputs = rollout_policy(self.model, batch, self.feature_builder)
-                    metrics = compute_metrics(outputs)
-                    for key, value in metrics.items():
-                        eval_logs[f"test/{test_dataset.env}/{key}"] = value
+            for name, test_dataset in self.data_module.test_sets().items():
+                batch = test_dataset.full(self.device)
+                outputs = rollout_policy(self.model, batch, self.feature_builder)
+                metrics = compute_metrics(outputs)
+                env_name = test_dataset.env if test_dataset.env else name
+                for key, value in metrics.items():
+                    eval_logs[f"test/{env_name}/{key}"] = value
+                if test_env and env_name == test_env:
                     crisis_cvar = metrics.get("cvar_95")
                     if crisis_cvar is not None:
                         if self.best_val_metric is None or crisis_cvar < self.best_val_metric:


### PR DESCRIPTION
## Summary
- restrict the volatility training environments to the low and medium regimes while keeping high for validation
- harden the data module and GroupDRO algorithm to work with arbitrary training-environment lists
- expand evaluation logging to cover all crisis stress scenarios during testing

## Testing
- PYTHONPATH=src python -m hirm_experiment.cli.train project.output_dir=outputs/smoke_test logging.enabled=false training.total_steps=5 training.log_interval=1 training.eval_interval=2 training.save_interval=0 training.batch_size=8 data.train_episodes=8 data.val_episodes=4 data.test_episodes=4 data.episode_length=10 algorithm.pretrain_steps=0 algorithm.ramp_steps=1 algorithm.lambda_target=1.0


------
https://chatgpt.com/codex/tasks/task_e_68ce824375108331935a259c9f3f2fca