### PR TITLE
Add real market loaders and dataset controls

### DIFF
--- a/configs/data/regimes.yaml
+++ b/configs/data/regimes.yaml
@@ -1,4 +1,5 @@
 name: volatility_regimes
+dataset_type: synthetic
 train_environments: [low, medium, high]
 val_environment: high
 test_environment: crisis
@@ -51,3 +52,71 @@ tx_costs:
     linear: 0.002
     quadratic: 0.1
 shuffle: true
+real_data:
+  spy_options_path: data/spy_options_2016_2023.csv
+  es_futures_path: data/es_futures_2016_2023.csv
+  start_date: 2016-01-01
+  end_date: 2023-12-31
+  interpolation_method: time
+  target_dte: 60
+  realized_vol_window: 20
+  realized_skew_window: 60
+  options_columns:
+    date: quote_date
+    expiration: expiration
+    strike: strike
+    bid: bid
+    ask: ask
+    volume: volume
+    open_interest: open_interest
+    underlying: underlying_price
+    implied_vol: implied_volatility
+  futures_columns:
+    date: trade_date
+    close: settle
+  filters:
+    min_open_interest: 500
+    min_volume: 50
+    max_rel_spread: 0.05
+    max_abs_spread: 0.15
+  tx_costs:
+    default:
+      linear: 0.001
+      quadratic: 0.05
+    stress:
+      linear: 0.0015
+      quadratic: 0.08
+    crisis:
+      linear: 0.002
+      quadratic: 0.1
+  train_windows:
+    - name: calm_pre_volmageddon
+      start: 2016-01-04
+      end: 2017-12-29
+      cost_profile: default
+  val_windows:
+    - name: transition_2019
+      start: 2019-01-02
+      end: 2019-12-31
+      cost_profile: stress
+  test_windows:
+    - name: post_covid_recovery
+      start: 2020-06-01
+      end: 2021-12-31
+      cost_profile: default
+  crisis_windows:
+    - name: volmageddon_2018
+      start: 2018-01-02
+      end: 2018-06-29
+      cost_profile: crisis
+    - name: covid_crash
+      start: 2020-02-01
+      end: 2020-04-30
+      cost_profile: crisis
+    - name: inflation_shock_2022
+      start: 2022-03-01
+      end: 2022-10-31
+      cost_profile: crisis
+combined:
+  synthetic_batch_ratio: 0.5
+  real_batch_ratio: 0.5

--- a/src/hirm_experiment/algorithms/base.py
+++ b/src/hirm_experiment/algorithms/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict
 
 import torch
 from torch import nn

--- a/src/hirm_experiment/analysis/report.py
+++ b/src/hirm_experiment/analysis/report.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Any, Dict
 
 import matplotlib.pyplot as plt
 import pandas as pd
 
 
-def coverage_table(coverage: Dict[str, Dict[str, float]]) -> pd.DataFrame:
+def coverage_table(coverage: Dict[str, Dict[str, Any]]) -> pd.DataFrame:
     if not coverage:
         return pd.DataFrame()
     df = pd.DataFrame.from_dict(coverage, orient="index")

--- a/src/hirm_experiment/cli/evaluate.py
+++ b/src/hirm_experiment/cli/evaluate.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import hydra
 import torch
@@ -65,7 +65,7 @@ def _aggregate_results(per_seed: Dict[int, EvaluationResult]) -> Dict[str, Dict[
     return aggregated
 
 
-def _coverage_snapshot(per_seed: Dict[int, EvaluationResult]) -> Dict[str, Dict[str, float]]:
+def _coverage_snapshot(per_seed: Dict[int, EvaluationResult]) -> Dict[str, Dict[str, Any]]:
     if not per_seed:
         return {}
     first = next(iter(per_seed.values()))

--- a/src/hirm_experiment/data/dataset.py
+++ b/src/hirm_experiment/data/dataset.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Protocol, Tuple
 
 import numpy as np
 import torch
 
-from .generator import SimulationResult, TransactionCostSpec, VolatilityRegimeSimulator, build_simulator_from_config
+from .generator import SimulationResult, TransactionCostSpec, build_simulator_from_config
+from .real_market import RealMarketLoader
 
 
 @dataclass
@@ -50,6 +51,8 @@ class RegimeDataset:
         horizon = self.spot.shape[1] - 1
         self.tx_linear = torch.full((self.spot.shape[0], horizon), result.tx_cost.linear, dtype=torch.float32)
         self.tx_quadratic = torch.full((self.spot.shape[0], horizon), result.tx_cost.quadratic, dtype=torch.float32)
+        self.metadata: Dict[str, Any] = dict(result.metadata or {})
+        self.metadata.setdefault("env", self.env)
 
     @property
     def episodes(self) -> int:
@@ -103,6 +106,24 @@ class FeatureStats:
         return (value - mean) / std
 
 
+def _compute_stats_from_datasets(datasets: Iterable[RegimeDataset]) -> Dict[str, FeatureStats]:
+    items = list(datasets)
+    if not items:
+        raise ValueError("No datasets available to compute feature statistics.")
+    delta_tensor = torch.cat([ds.delta for ds in items], dim=0)
+    gamma_tensor = torch.cat([ds.gamma for ds in items], dim=0)
+    tau_tensor = torch.cat([torch.full_like(ds.delta, 60.0 / 252.0) for ds in items], dim=0)
+    vol_tensor = torch.cat([ds.realized_vol for ds in items], dim=0)
+    stats = {
+        "delta": FeatureStats(delta_tensor.mean(), delta_tensor.std(unbiased=False)),
+        "gamma": FeatureStats(gamma_tensor.mean(), gamma_tensor.std(unbiased=False)),
+        "tau": FeatureStats(tau_tensor.mean(), tau_tensor.std(unbiased=False)),
+        "realized_vol": FeatureStats(vol_tensor.mean(), vol_tensor.std(unbiased=False)),
+        "inventory": FeatureStats(torch.tensor(0.0), torch.tensor(1.0)),
+    }
+    return stats
+
+
 class VolatilityRegimeDataModule:
     def __init__(
         self,
@@ -141,6 +162,14 @@ class VolatilityRegimeDataModule:
             base = self.config["test_environment"]
             result = self.simulator.generate(base, self.config["test_episodes"], seed=int(rng.integers(0, 1_000_000)), with_jump=True)
             result.env = f"{base}_jump"
+            metadata = dict(result.metadata or {})
+            metadata.update({
+                "env": result.env,
+                "variant": "jump",
+                "base_env": base,
+                "source": metadata.get("source", "synthetic"),
+            })
+            result.metadata = metadata
             return result, result.env
         if env == "liquidity":
             base = self.config["test_environment"]
@@ -150,30 +179,25 @@ class VolatilityRegimeDataModule:
             quadratic = max(result.tx_cost.quadratic, stress_cost.get("stress_quadratic", 0.2))
             result.tx_cost = TransactionCostSpec(linear=float(linear), quadratic=float(quadratic))
             result.env = f"{base}_liquidity"
+            metadata = dict(result.metadata or {})
+            metadata.update({
+                "env": result.env,
+                "variant": "liquidity",
+                "base_env": base,
+                "tx_cost_override": {"linear": float(linear), "quadratic": float(quadratic)},
+                "source": metadata.get("source", "synthetic"),
+            })
+            result.metadata = metadata
             return result, result.env
         result = self.simulator.generate(env, self.config["test_episodes"], seed=int(rng.integers(0, 1_000_000)))
+        metadata = dict(result.metadata or {})
+        metadata.setdefault("env", env)
+        result.metadata = metadata
         return result, env
 
     def _compute_feature_stats(self) -> Dict[str, FeatureStats]:
-        delta_list, gamma_list, tau_list, vol_list = [], [], [], []
-        for env in self.train_envs:
-            ds = self.datasets[env]
-            delta_list.append(ds.delta)
-            gamma_list.append(ds.gamma)
-            tau_list.append(torch.full_like(ds.delta, 60.0 / 252.0))
-            vol_list.append(ds.realized_vol)
-        delta_tensor = torch.cat(delta_list, dim=0)
-        gamma_tensor = torch.cat(gamma_list, dim=0)
-        tau_tensor = torch.cat(tau_list, dim=0)
-        vol_tensor = torch.cat(vol_list, dim=0)
-        stats = {
-            "delta": FeatureStats(delta_tensor.mean(), delta_tensor.std(unbiased=False)),
-            "gamma": FeatureStats(gamma_tensor.mean(), gamma_tensor.std(unbiased=False)),
-            "tau": FeatureStats(tau_tensor.mean(), tau_tensor.std(unbiased=False)),
-            "realized_vol": FeatureStats(vol_tensor.mean(), vol_tensor.std(unbiased=False)),
-            "inventory": FeatureStats(torch.tensor(0.0), torch.tensor(1.0)),
-        }
-        return stats
+        datasets = [self.datasets[env] for env in self.train_envs]
+        return _compute_stats_from_datasets(datasets)
 
     def sample_train_batches(self, batch_size: int) -> Dict[str, EpisodeBatch]:
         per_env = max(batch_size // len(self.train_envs), 1)
@@ -193,5 +217,197 @@ class VolatilityRegimeDataModule:
         return self.feature_stats
 
 
-def create_data_module(config: Dict, seed: int, device: torch.device) -> VolatilityRegimeDataModule:
-    return VolatilityRegimeDataModule(config, seed, device)
+class RealMarketDataModule:
+    def __init__(
+        self,
+        config: Dict,
+        seed: int,
+        device: torch.device,
+    ) -> None:
+        del seed  # Real data loading is deterministic
+        self.config = config
+        self.device = device
+        self.real_config = config.get("real_data")
+        if not self.real_config:
+            raise ValueError("data.real_data must be provided when dataset_type='real' or 'combined'.")
+        episode_length = int(config.get("episode_length", 60))
+        self.loader = RealMarketLoader(self.real_config, episode_length)
+        self.train_envs: List[str] = []
+        self.val_envs: List[str] = []
+        self.test_envs: List[str] = []
+        self.datasets: Dict[str, RegimeDataset] = {}
+        self.val_datasets: Dict[str, RegimeDataset] = {}
+        self.test_datasets: Dict[str, RegimeDataset] = {}
+        self._build_splits()
+        self.feature_stats = self._compute_feature_stats()
+
+    def _window_definitions(self, key: str) -> List[Dict[str, Any]]:
+        windows = self.real_config.get(key, [])
+        return [dict(window) for window in windows]
+
+    def _build_group(
+        self,
+        key: str,
+        tag: str,
+        target: Dict[str, RegimeDataset],
+        collector: List[str],
+    ) -> None:
+        for window in self._window_definitions(key):
+            result = self.loader.build_window(window, tag)
+            dataset = RegimeDataset(result)
+            target[result.env] = dataset
+            collector.append(result.env)
+
+    def _build_splits(self) -> None:
+        self._build_group("train_windows", "train", self.datasets, self.train_envs)
+        self._build_group("val_windows", "validation", self.val_datasets, self.val_envs)
+        self._build_group("test_windows", "test", self.test_datasets, self.test_envs)
+        self._build_group("crisis_windows", "crisis", self.test_datasets, self.test_envs)
+
+    def _compute_feature_stats(self) -> Dict[str, FeatureStats]:
+        datasets: List[RegimeDataset] = [self.datasets[name] for name in self.train_envs]
+        if not datasets:
+            datasets = list(self.datasets.values())
+        if not datasets:
+            datasets = list(self.val_datasets.values())
+        if not datasets:
+            datasets = list(self.test_datasets.values())
+        if not datasets:
+            raise ValueError("RealMarketDataModule could not find any datasets to compute statistics.")
+        return _compute_stats_from_datasets(datasets)
+
+    def sample_train_batches(self, batch_size: int) -> Dict[str, EpisodeBatch]:
+        if not self.train_envs:
+            return {}
+        per_env = max(batch_size // len(self.train_envs), 1)
+        return {env: self.datasets[env].sample(per_env, self.device) for env in self.train_envs}
+
+    def sample_validation(self, env: Optional[str] = None) -> Dict[str, EpisodeBatch]:
+        if not self.val_envs:
+            return {}
+        if env is not None:
+            if env not in self.val_datasets:
+                raise KeyError(f"Unknown validation environment: {env}")
+            return {env: self.val_datasets[env].full(self.device)}
+        return {name: ds.full(self.device) for name, ds in self.val_datasets.items()}
+
+    def test_sets(self) -> Dict[str, RegimeDataset]:
+        return self.test_datasets
+
+    def get_feature_stats(self) -> Dict[str, FeatureStats]:
+        return self.feature_stats
+
+
+class CombinedDataModule:
+    def __init__(
+        self,
+        config: Dict,
+        seed: int,
+        device: torch.device,
+    ) -> None:
+        self.config = config
+        self.device = device
+        self.synthetic = VolatilityRegimeDataModule(config, seed, device)
+        self.real = RealMarketDataModule(config, seed, device)
+        self.combined_config = config.get("combined", {})
+        self.train_envs = list(self.synthetic.train_envs) + list(self.real.train_envs)
+        self.feature_stats = self._compute_feature_stats()
+
+    def _compute_feature_stats(self) -> Dict[str, FeatureStats]:
+        datasets: List[RegimeDataset] = [self.synthetic.datasets[env] for env in self.synthetic.train_envs]
+        datasets.extend(self.real.datasets[env] for env in self.real.train_envs)
+        if not datasets:
+            if self.synthetic.datasets:
+                datasets = list(self.synthetic.datasets.values())
+            elif self.real.datasets or self.real.val_datasets or self.real.test_datasets:
+                datasets = list(self.real.datasets.values())
+                if not datasets:
+                    datasets = list(self.real.val_datasets.values())
+                if not datasets:
+                    datasets = list(self.real.test_datasets.values())
+        if not datasets:
+            raise ValueError("CombinedDataModule has no datasets available for feature statistics.")
+        return _compute_stats_from_datasets(datasets)
+
+    def _split_batch_size(self, batch_size: int) -> Tuple[int, int, bool, bool]:
+        syn_ratio_raw = max(float(self.combined_config.get("synthetic_batch_ratio", 0.5)), 0.0)
+        real_ratio_raw = max(float(self.combined_config.get("real_batch_ratio", 0.5)), 0.0)
+        include_synthetic = bool(self.synthetic.train_envs) and (
+            syn_ratio_raw > 0.0 or not self.real.train_envs or (syn_ratio_raw == 0.0 and real_ratio_raw == 0.0)
+        )
+        include_real = bool(self.real.train_envs) and (
+            real_ratio_raw > 0.0 or not self.synthetic.train_envs or (syn_ratio_raw == 0.0 and real_ratio_raw == 0.0)
+        )
+        total = syn_ratio_raw + real_ratio_raw
+        if total == 0.0:
+            syn_share = 0.5 if include_synthetic else 0.0
+            real_share = 0.5 if include_real else 0.0
+        else:
+            syn_share = syn_ratio_raw / total if include_synthetic else 0.0
+            real_share = real_ratio_raw / total if include_real else 0.0
+        synthetic_size = int(round(batch_size * syn_share)) if include_synthetic else 0
+        real_size = int(round(batch_size * real_share)) if include_real else 0
+        return synthetic_size, real_size, include_synthetic, include_real
+
+    def sample_train_batches(self, batch_size: int) -> Dict[str, EpisodeBatch]:
+        if not self.train_envs:
+            return {}
+        synthetic_size, real_size, include_synthetic, include_real = self._split_batch_size(batch_size)
+        batches: Dict[str, EpisodeBatch] = {}
+        if include_synthetic:
+            size = max(synthetic_size, len(self.synthetic.train_envs))
+            batches.update(self.synthetic.sample_train_batches(size))
+        if include_real:
+            size = max(real_size, len(self.real.train_envs))
+            batches.update(self.real.sample_train_batches(size))
+        return batches
+
+    def sample_validation(self, env: Optional[str] = None) -> Dict[str, EpisodeBatch]:
+        if env is not None:
+            if env in self.synthetic.val_datasets:
+                return self.synthetic.sample_validation(env)
+            if env in self.real.val_datasets:
+                return self.real.sample_validation(env)
+            raise KeyError(f"Unknown validation environment: {env}")
+        batches: Dict[str, EpisodeBatch] = {}
+        if self.synthetic.val_envs:
+            batches.update(self.synthetic.sample_validation())
+        if self.real.val_envs:
+            batches.update(self.real.sample_validation())
+        return batches
+
+    def test_sets(self) -> Dict[str, RegimeDataset]:
+        datasets: Dict[str, RegimeDataset] = {}
+        datasets.update(self.synthetic.test_sets())
+        datasets.update(self.real.test_sets())
+        return datasets
+
+    def get_feature_stats(self) -> Dict[str, FeatureStats]:
+        return self.feature_stats
+
+
+class DataModule(Protocol):
+    train_envs: List[str]
+
+    def sample_train_batches(self, batch_size: int) -> Dict[str, EpisodeBatch]:
+        ...
+
+    def sample_validation(self, env: Optional[str] = None) -> Dict[str, EpisodeBatch]:
+        ...
+
+    def test_sets(self) -> Dict[str, RegimeDataset]:
+        ...
+
+    def get_feature_stats(self) -> Dict[str, FeatureStats]:
+        ...
+
+
+def create_data_module(config: Dict, seed: int, device: torch.device) -> DataModule:
+    dataset_type = config.get("dataset_type", "synthetic")
+    if dataset_type == "synthetic":
+        return VolatilityRegimeDataModule(config, seed, device)
+    if dataset_type == "real":
+        return RealMarketDataModule(config, seed, device)
+    if dataset_type == "combined":
+        return CombinedDataModule(config, seed, device)
+    raise ValueError(f"Unsupported dataset_type: {dataset_type}")

--- a/src/hirm_experiment/data/real_market.py
+++ b/src/hirm_experiment/data/real_market.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+import numpy as np
+import pandas as pd
+from numpy.lib.stride_tricks import sliding_window_view
+
+from .black_scholes import greeks
+from .generator import SimulationResult, TransactionCostSpec
+
+
+def _rolling_realized_vol(log_returns: pd.Series, window: int) -> pd.Series:
+    window = max(int(window), 2)
+    vol = log_returns.rolling(window, min_periods=2).std(ddof=0)
+    return vol * np.sqrt(252.0)
+
+
+def _rolling_skew(log_returns: pd.Series, window: int) -> pd.Series:
+    window = max(int(window), 3)
+
+    def _skew(values: np.ndarray) -> float:
+        valid = values[~np.isnan(values)]
+        if valid.size < 3:
+            return float("nan")
+        centered = valid - valid.mean()
+        variance = np.mean(centered ** 2)
+        if variance <= 1e-12:
+            return 0.0
+        return float(np.mean(centered ** 3) / (variance ** 1.5))
+
+    return log_returns.rolling(window, min_periods=3).apply(_skew, raw=True)
+
+
+def _sanitize_name(name: str) -> str:
+    sanitized = "".join(ch.lower() if ch.isalnum() else "_" for ch in name)
+    while "__" in sanitized:
+        sanitized = sanitized.replace("__", "_")
+    return sanitized.strip("_")
+
+
+class RealMarketLoader:
+    def __init__(self, config: Dict[str, Any], episode_length: int) -> None:
+        self.config = config
+        self.episode_length = int(episode_length)
+        self.options_path = Path(config["spy_options_path"])
+        self.futures_path = Path(config["es_futures_path"])
+        self.target_dte = int(config.get("target_dte", 60))
+        self.start_date = pd.Timestamp(config.get("start_date", "2016-01-01")).tz_localize(None)
+        self.end_date = pd.Timestamp(config.get("end_date", "2023-12-31")).tz_localize(None)
+        self.interpolation_method = config.get("interpolation_method", "time")
+        filters = config.get("filters", {})
+        self.filters = {
+            "min_open_interest": int(filters.get("min_open_interest", 500)),
+            "min_volume": int(filters.get("min_volume", 50)),
+            "max_rel_spread": float(filters.get("max_rel_spread", 0.05)),
+            "max_abs_spread": float(filters.get("max_abs_spread", 0.15)),
+        }
+        self.realized_vol_window = int(config.get("realized_vol_window", 20))
+        self.realized_skew_window = int(config.get("realized_skew_window", 60))
+        self.options_columns = self._resolve_option_columns(config.get("options_columns", {}))
+        self.futures_columns = self._resolve_futures_columns(config.get("futures_columns", {}))
+        self.tx_costs = config.get("tx_costs", {})
+        self._cache: Optional[pd.DataFrame] = None
+
+    def _resolve_option_columns(self, overrides: Dict[str, str]) -> Dict[str, str]:
+        defaults = {
+            "date": "quote_date",
+            "expiration": "expiration",
+            "strike": "strike",
+            "bid": "bid",
+            "ask": "ask",
+            "volume": "volume",
+            "open_interest": "open_interest",
+            "underlying": "underlying_price",
+            "implied_vol": "implied_volatility",
+        }
+        defaults.update({k: v for k, v in overrides.items() if v})
+        return defaults
+
+    def _resolve_futures_columns(self, overrides: Dict[str, str]) -> Dict[str, str]:
+        defaults = {
+            "date": "date",
+            "close": "settle",
+        }
+        defaults.update({k: v for k, v in overrides.items() if v})
+        return defaults
+
+    def combined_frame(self) -> pd.DataFrame:
+        if self._cache is None:
+            futures = self._load_futures()
+            options = self._load_options(futures.index)
+            combined = self._merge_frames(options, futures)
+            mask = (combined.index >= self.start_date) & (combined.index <= self.end_date)
+            self._cache = combined.loc[mask].copy()
+        return self._cache.copy()
+
+    def build_window(self, window: Dict[str, Any], tag: str) -> SimulationResult:
+        frame = self.combined_frame()
+        start = pd.Timestamp(window["start"]).tz_localize(None)
+        end = pd.Timestamp(window["end"]).tz_localize(None)
+        window_frame = frame.loc[(frame.index >= start) & (frame.index <= end)].copy()
+        if window_frame.empty:
+            name = window.get("name", f"{start.date()}_{end.date()}")
+            raise ValueError(f"Window '{name}' returned no observations in the real data loader.")
+        if window_frame.shape[0] <= self.episode_length:
+            name = window.get("name", f"{start.date()}_{end.date()}")
+            raise ValueError(
+                f"Window '{name}' with {window_frame.shape[0]} rows is shorter than the episode length {self.episode_length}."
+            )
+        arrays = self._frame_to_arrays(window_frame)
+        env_name = self._resolve_env_name(window, tag)
+        tx_cost = self._resolve_cost(window, tag)
+        metadata = self._window_metadata(window, tag, window_frame, tx_cost, env_name)
+        metadata["env"] = env_name
+        metadata["episode_count"] = int(arrays["spot"].shape[0])
+        return SimulationResult(
+            env=env_name,
+            spot=arrays["spot"],
+            delta=arrays["delta"],
+            gamma=arrays["gamma"],
+            theta=arrays["theta"],
+            realized_vol=arrays["realized_vol"],
+            implied_vol=arrays["implied_vol"],
+            option_price=arrays["option_price"],
+            tx_cost=tx_cost,
+            metadata=metadata,
+        )
+
+    def _read_table(self, path: Path, parse_dates: Iterable[str]) -> pd.DataFrame:
+        suffix = path.suffix.lower()
+        if suffix in {".parquet", ".pq"}:
+            df = pd.read_parquet(path)
+        else:
+            df = pd.read_csv(path)
+        for column in parse_dates:
+            if column in df.columns:
+                df[column] = pd.to_datetime(df[column])
+        return df
+
+    def _load_futures(self) -> pd.DataFrame:
+        date_col = self.futures_columns["date"]
+        close_col = self.futures_columns["close"]
+        df = self._read_table(self.futures_path, [date_col])
+        if date_col not in df.columns or close_col not in df.columns:
+            raise ValueError("Futures data must contain date and close columns for preprocessing.")
+        df = df[[date_col, close_col]].copy()
+        df[close_col] = pd.to_numeric(df[close_col], errors="coerce")
+        df = df.dropna(subset=[close_col])
+        df = df.sort_values(date_col).drop_duplicates(date_col, keep="last")
+        df[date_col] = pd.to_datetime(df[date_col]).dt.tz_localize(None)
+        df = df[(df[date_col] >= self.start_date) & (df[date_col] <= self.end_date)]
+        df = df.set_index(date_col)
+        business_index = pd.date_range(self.start_date, self.end_date, freq="B")
+        df = df.reindex(business_index)
+        df[close_col] = df[close_col].interpolate(method=self.interpolation_method, limit_direction="both")
+        log_returns = np.log(df[close_col]).diff()
+        df["realized_vol"] = _rolling_realized_vol(log_returns, self.realized_vol_window)
+        df["realized_skew"] = _rolling_skew(log_returns, self.realized_skew_window)
+        df[["realized_vol", "realized_skew"]] = df[["realized_vol", "realized_skew"]].interpolate(
+            method=self.interpolation_method, limit_direction="both"
+        )
+        df = df.dropna(subset=[close_col])
+        df.rename(columns={close_col: "futures_close"}, inplace=True)
+        return df[["futures_close", "realized_vol", "realized_skew"]]
+
+    def _load_options(self, target_index: pd.DatetimeIndex) -> pd.DataFrame:
+        cols = self.options_columns
+        parse_cols = [cols["date"], cols["expiration"]]
+        df = self._read_table(self.options_path, parse_cols)
+        rename_map = {
+            cols["date"]: "date",
+            cols["expiration"]: "expiration",
+            cols["strike"]: "strike",
+            cols["bid"]: "bid",
+            cols["ask"]: "ask",
+            cols["volume"]: "volume",
+            cols["open_interest"]: "open_interest",
+            cols["underlying"]: "underlying",
+        }
+        implied_col = cols.get("implied_vol")
+        if implied_col:
+            rename_map[implied_col] = "implied_vol"
+        df = df.rename(columns=rename_map)
+        required = ["date", "expiration", "strike", "bid", "ask", "volume", "open_interest", "underlying"]
+        missing = [column for column in required if column not in df.columns]
+        if missing:
+            raise ValueError(f"Options data is missing required columns: {missing}")
+        numeric_cols = ["strike", "bid", "ask", "volume", "open_interest", "underlying"]
+        for column in numeric_cols:
+            df[column] = pd.to_numeric(df[column], errors="coerce")
+        if "implied_vol" in df.columns:
+            df["implied_vol"] = pd.to_numeric(df["implied_vol"], errors="coerce")
+        df["date"] = pd.to_datetime(df["date"]).dt.tz_localize(None)
+        df["expiration"] = pd.to_datetime(df["expiration"]).dt.tz_localize(None)
+        df = df[(df["date"] >= self.start_date) & (df["date"] <= self.end_date)]
+        df["mid"] = 0.5 * (df["bid"] + df["ask"])
+        df = df.dropna(subset=["mid", "underlying", "strike"])
+        df = df[df["open_interest"] >= self.filters["min_open_interest"]]
+        df = df[df["volume"] >= self.filters["min_volume"]]
+        df = df[(df["bid"] > 0) & (df["ask"] > 0) & (df["mid"] > 0)]
+        df["spread"] = df["ask"] - df["bid"]
+        spread_cap = np.maximum(self.filters["max_abs_spread"], self.filters["max_rel_spread"] * df["mid"])
+        df = df[df["spread"] <= spread_cap]
+        df["dte"] = (df["expiration"] - df["date"]).dt.days
+        df = df[df["dte"] > 0]
+        df["atm_distance"] = (df["strike"] - df["underlying"]).abs() / df["underlying"].replace(0, np.nan)
+        df["dte_distance"] = (df["dte"] - self.target_dte).abs()
+        df = df.sort_values(["date", "dte_distance", "atm_distance", "volume"], ascending=[True, True, True, False])
+        atm = df.groupby("date").head(1).copy()
+        atm = atm.set_index("date").reindex(target_index)
+        atm["underlying"] = atm["underlying"].interpolate(method=self.interpolation_method, limit_direction="both")
+        atm["mid"] = atm["mid"].interpolate(method=self.interpolation_method, limit_direction="both")
+        atm["dte"] = atm["dte"].fillna(self.target_dte)
+        if "implied_vol" in atm.columns:
+            atm["implied_vol"] = atm["implied_vol"].replace(0.0, np.nan)
+            atm["implied_vol"] = atm["implied_vol"].interpolate(method=self.interpolation_method, limit_direction="both")
+            atm["implied_vol"] = atm["implied_vol"].ffill().bfill()
+        else:
+            atm["implied_vol"] = np.nan
+        if atm["implied_vol"].isna().all():
+            atm["implied_vol"] = 0.2
+        atm["implied_vol"] = atm["implied_vol"].fillna(atm["implied_vol"].mean()).fillna(0.2)
+        atm["tau"] = atm["dte"].astype(float) / 252.0
+        atm["tau"] = atm["tau"].clip(lower=1e-6)
+        atm["spot"] = atm["underlying"]
+        spot = atm["spot"].to_numpy(dtype=np.float64)
+        tau = atm["tau"].to_numpy(dtype=np.float64)
+        sigma = np.clip(atm["implied_vol"].to_numpy(dtype=np.float64), 1e-4, None)
+        delta, gamma, theta = greeks(spot, tau, sigma)
+        atm["delta"] = delta.astype(np.float32)
+        atm["gamma"] = gamma.astype(np.float32)
+        atm["theta"] = theta.astype(np.float32)
+        atm["implied_vol"] = sigma.astype(np.float32)
+        atm["option_price"] = atm["mid"].astype(np.float32)
+        return atm
+
+    def _merge_frames(self, options: pd.DataFrame, futures: pd.DataFrame) -> pd.DataFrame:
+        combined = options.join(futures, how="inner")
+        combined = combined.interpolate(method=self.interpolation_method, limit_direction="both")
+        required = ["spot", "option_price", "delta", "gamma", "theta", "implied_vol", "realized_vol"]
+        combined = combined.dropna(subset=required)
+        combined = combined.sort_index()
+        return combined
+
+    def _resolve_env_name(self, window: Dict[str, Any], tag: str) -> str:
+        base_name = window.get("name")
+        if base_name:
+            sanitized = _sanitize_name(str(base_name))
+        else:
+            start = pd.Timestamp(window["start"]).strftime("%Y%m%d")
+            end = pd.Timestamp(window["end"]).strftime("%Y%m%d")
+            sanitized = f"{start}_{end}"
+        return f"real_{tag}_{sanitized}"
+
+    def _resolve_cost(self, window: Dict[str, Any], tag: str) -> TransactionCostSpec:
+        profile = window.get("cost_profile")
+        if not profile:
+            profile = "crisis" if tag == "crisis" else "default"
+        default_cost = self.tx_costs.get("default", {"linear": 0.001, "quadratic": 0.05})
+        profile_cost = self.tx_costs.get(profile, default_cost)
+        linear = float(window.get("tx_linear", profile_cost.get("linear", default_cost.get("linear", 0.001))))
+        quadratic = float(window.get("tx_quadratic", profile_cost.get("quadratic", default_cost.get("quadratic", 0.05))))
+        return TransactionCostSpec(linear=linear, quadratic=quadratic)
+
+    def _window_metadata(
+        self,
+        window: Dict[str, Any],
+        tag: str,
+        frame: pd.DataFrame,
+        tx_cost: TransactionCostSpec,
+        env_name: str,
+    ) -> Dict[str, Any]:
+        start = pd.Timestamp(window["start"]).tz_localize(None)
+        end = pd.Timestamp(window["end"]).tz_localize(None)
+        metadata = {
+            "source": "real",
+            "window_name": window.get("name", env_name),
+            "window_type": tag,
+            "window_start": start.strftime("%Y-%m-%d"),
+            "window_end": end.strftime("%Y-%m-%d"),
+            "options_path": str(self.options_path),
+            "futures_path": str(self.futures_path),
+            "target_dte": self.target_dte,
+            "episode_length": self.episode_length,
+            "realized_vol_window": self.realized_vol_window,
+            "realized_skew_window": self.realized_skew_window,
+            "episode_sampling": {"method": "sliding_window", "horizon": self.episode_length},
+            "tx_cost": {"linear": tx_cost.linear, "quadratic": tx_cost.quadratic},
+            "total_days": int(frame.shape[0]),
+        }
+        if tag == "crisis" or window.get("crisis", False):
+            metadata["crisis"] = True
+        if "realized_vol" in frame.columns:
+            metadata["avg_realized_vol"] = float(frame["realized_vol"].mean())
+        if "realized_skew" in frame.columns:
+            metadata["avg_realized_skew"] = float(frame["realized_skew"].mean())
+        return metadata
+
+    def _frame_to_arrays(self, frame: pd.DataFrame) -> Dict[str, np.ndarray]:
+        required = ["spot", "delta", "gamma", "theta", "realized_vol", "implied_vol", "option_price"]
+        missing_columns = [column for column in required if column not in frame.columns]
+        if missing_columns:
+            raise ValueError(f"Real market frame is missing required columns: {missing_columns}")
+        for column in required:
+            if frame[column].isna().any():
+                frame[column] = frame[column].interpolate(method=self.interpolation_method, limit_direction="both")
+                frame[column] = frame[column].ffill().bfill()
+        horizon = self.episode_length
+        spot_series = frame["spot"].to_numpy(dtype=np.float32)
+        delta_series = frame["delta"].to_numpy(dtype=np.float32)
+        gamma_series = frame["gamma"].to_numpy(dtype=np.float32)
+        theta_series = frame["theta"].to_numpy(dtype=np.float32)
+        realized_vol_series = frame["realized_vol"].to_numpy(dtype=np.float32)
+        implied_vol_series = frame["implied_vol"].to_numpy(dtype=np.float32)
+        option_price_series = frame["option_price"].to_numpy(dtype=np.float32)
+        spot_windows = sliding_window_view(spot_series, horizon + 1).copy()
+        delta_windows = sliding_window_view(delta_series, horizon).copy()
+        gamma_windows = sliding_window_view(gamma_series, horizon).copy()
+        theta_windows = sliding_window_view(theta_series, horizon).copy()
+        realized_vol_windows = sliding_window_view(realized_vol_series, horizon).copy()
+        implied_vol_windows = sliding_window_view(implied_vol_series, horizon).copy()
+        option_price_windows = sliding_window_view(option_price_series, horizon).copy()
+        return {
+            "spot": spot_windows,
+            "delta": delta_windows,
+            "gamma": gamma_windows,
+            "theta": theta_windows,
+            "realized_vol": realized_vol_windows,
+            "implied_vol": implied_vol_windows,
+            "option_price": option_price_windows,
+        }

--- a/src/hirm_experiment/evaluation/metrics.py
+++ b/src/hirm_experiment/evaluation/metrics.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Dict, Iterable, Tuple
 
 import torch

--- a/src/hirm_experiment/training/engine.py
+++ b/src/hirm_experiment/training/engine.py
@@ -4,12 +4,11 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import torch
-from torch import nn
 from torch.nn.utils import clip_grad_norm_
 from torch.optim import Adam
 
 from hirm_experiment.algorithms import build_algorithm
-from hirm_experiment.data.dataset import VolatilityRegimeDataModule, create_data_module
+from hirm_experiment.data.dataset import create_data_module
 from hirm_experiment.evaluation.metrics import compute_metrics
 from hirm_experiment.models.policy import HedgingPolicy, HedgingPolicyConfig
 from hirm_experiment.training.features import FeatureBuilder

--- a/src/hirm_experiment/training/features.py
+++ b/src/hirm_experiment/training/features.py
@@ -16,7 +16,6 @@ class FeatureBuilder:
 
     def step_features(self, batch: EpisodeBatch, t: int, inventory: torch.Tensor) -> torch.Tensor:
         components: List[torch.Tensor] = []
-        device = batch.delta.device
         for name in self.invariants + self.spurious:
             components.append(self._feature(name, batch, t, inventory).unsqueeze(-1))
         return torch.cat(components, dim=-1)

--- a/src/hirm_experiment/training/utils.py
+++ b/src/hirm_experiment/training/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import random
-from typing import Optional
 
 import numpy as np
 import torch


### PR DESCRIPTION
## Summary
- add a real-market loader for SPY options and S&P E-mini futures with cleaning, interpolation, and realized vol/skew features
- extend the data module factory to support synthetic, real, and combined datasets with coverage metadata indicating sample origin
- update Hydra data configs and evaluation utilities to expose dataset toggles and preserve reproducible crisis window logging

## Testing
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68ce8244a0a88331af15b0ebebe66e2a