### PR TITLE
Improve environment setup utilities and add diagnostics configurability

### DIFF
--- a/configs/eval/daily.yaml
+++ b/configs/eval/daily.yaml
@@ -3,6 +3,9 @@ seeds: [0, 1, 2]
 compute_per_env_metrics: true
 compute_msi: false
 msi_batch_size: 512
+msi_feature_groups:
+  invariants: []
+  spurious: []
 report:
   alpha: 0.95
   bootstrap_samples: 1000

--- a/src/utils/configs.py
+++ b/src/utils/configs.py
@@ -1,10 +1,24 @@
 """Hydra configuration helpers."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
+
+from ..data.features import FeatureEngineer
+from ..data.synthetic import EpisodeBatch, SyntheticDataModule
+from ..envs.single_asset import SingleAssetHedgingEnv
+
+
+@dataclass(frozen=True)
+class DataModuleContext:
+    data_module: SyntheticDataModule
+    env_order: List[str]
+    name_to_index: Dict[str, int]
+    env_configs: Dict[str, Dict]
+    cost_configs: Dict[str, Dict]
 
 
 def load_yaml_config(path: str) -> Dict:
@@ -36,3 +50,37 @@ def environment_order(env_group: DictConfig) -> List[str]:
             if name not in order:
                 order.append(name)
     return order
+
+
+def unwrap_experiment_config(cfg: DictConfig) -> DictConfig:
+    if "train" in cfg and "data" not in cfg:
+        return cfg.train
+    return cfg
+
+
+def prepare_data_module(cfg: DictConfig) -> DataModuleContext:
+    env_cfgs, cost_cfgs, env_order = resolve_env_configs(cfg.envs)
+    data_module = SyntheticDataModule(
+        config=OmegaConf.to_container(cfg.data, resolve=True),
+        env_cfgs=env_cfgs,
+        cost_cfgs=cost_cfgs,
+    )
+    name_to_index = {name: idx for idx, name in enumerate(env_order)}
+    return DataModuleContext(
+        data_module=data_module,
+        env_order=env_order,
+        name_to_index=name_to_index,
+        env_configs=env_cfgs,
+        cost_configs=cost_cfgs,
+    )
+
+
+def build_envs(
+    batches: Dict[str, EpisodeBatch],
+    feature_engineer: FeatureEngineer,
+    name_to_index: Dict[str, int],
+) -> Dict[str, SingleAssetHedgingEnv]:
+    envs: Dict[str, SingleAssetHedgingEnv] = {}
+    for name, batch in batches.items():
+        envs[name] = SingleAssetHedgingEnv(name_to_index[name], batch, feature_engineer)
+    return envs

--- a/tests/test_checkpoint_manager.py
+++ b/tests/test_checkpoint_manager.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.utils.checkpoints import CheckpointManager
+
+
+def _collect_manifest(path: Path) -> list[dict]:
+    with (path / "manifest.json").open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_checkpoint_manager_restores_existing_entries(tmp_path):
+    manager = CheckpointManager(tmp_path, top_k=2)
+    manager.save(1, score=0.5, state={"step": 1})
+    manager.save(2, score=1.0, state={"step": 2})
+
+    restored = CheckpointManager(tmp_path, top_k=2)
+    scores = sorted(entry.score for entry in restored.heap)
+    assert scores == [0.5, 1.0]
+
+
+def test_checkpoint_manager_prunes_missing_and_excess_checkpoints(tmp_path):
+    manager = CheckpointManager(tmp_path, top_k=3)
+    for idx, score in enumerate([0.2, 0.4, 0.6], start=1):
+        manager.save(idx, score=score, state={"step": idx})
+
+    # Remove one checkpoint file to simulate manual deletion
+    missing_path = tmp_path / "checkpoint_1.pt"
+    missing_path.unlink()
+
+    restored = CheckpointManager(tmp_path, top_k=2)
+    scores = sorted(entry.score for entry in restored.heap)
+    assert scores == [0.4, 0.6]
+
+    manifest = _collect_manifest(tmp_path)
+    assert len(manifest) == 2

--- a/tests/test_feature_engineer_env.py
+++ b/tests/test_feature_engineer_env.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.data.features import FeatureEngineer
+from src.data.synthetic import EpisodeBatch
+from src.envs.single_asset import SingleAssetHedgingEnv
+from src import eval as eval_module
+
+
+def _make_episode_batch() -> EpisodeBatch:
+    spot = torch.tensor([[100.0, 102.0, 101.0]], dtype=torch.float32)
+    option = torch.tensor([[10.0, 11.0, 10.0]], dtype=torch.float32)
+    implied_vol = torch.full_like(spot, 0.2)
+    time_to_maturity = torch.tensor([[0.5, 0.496, 0.492]], dtype=torch.float32)
+    meta = {
+        "linear_bps": 0.0,
+        "quadratic": 0.0,
+        "slippage_multiplier": 1.0,
+        "notional": 1.0,
+    }
+    return EpisodeBatch(
+        spot=spot,
+        option_price=option,
+        implied_vol=implied_vol,
+        time_to_maturity=time_to_maturity,
+        rate=0.01,
+        env_name="unit-test",
+        meta=meta,
+    )
+
+
+def test_feature_engineer_fit_and_transform_matches_manual_scaling():
+    batch = _make_episode_batch()
+    inventory = torch.tensor([[0.0, 0.5]], dtype=torch.float32)
+
+    engineer = FeatureEngineer(realized_vol_window=2)
+    scaler = engineer.fit([batch])
+
+    transformed = engineer.transform(batch, inventory)
+    base = engineer.base_features(batch)
+    combined = torch.cat([base, inventory.unsqueeze(-1)], dim=-1)
+    expected = (combined - scaler.mean) / torch.clamp(scaler.std, min=1e-6)
+
+    torch.testing.assert_close(transformed, expected)
+
+
+def test_feature_engineer_transform_requires_fit():
+    batch = _make_episode_batch()
+    inventory = torch.zeros((1, batch.steps), dtype=torch.float32)
+    engineer = FeatureEngineer()
+
+    with pytest.raises(RuntimeError):
+        engineer.transform(batch, inventory)
+
+
+def test_feature_groups_respects_configuration_overrides():
+    feature_names = ["delta", "realized_vol", "inventory", "custom_feature"]
+    grouping_cfg = {
+        "invariants": ["realized_vol"],
+        "spurious": ["delta"],
+        "default": "spurious",
+    }
+
+    invariants, spurious = eval_module._feature_groups(feature_names, grouping_cfg)
+
+    invariant_names = {feature_names[i] for i in invariants}
+    spurious_names = {feature_names[i] for i in spurious}
+
+    assert "realized_vol" in invariant_names
+    assert "delta" in spurious_names
+    assert "custom_feature" in spurious_names
+
+
+class _StepPolicy:
+    def __init__(self, actions: list[float]):
+        self._actions = actions
+        self._idx = 0
+
+    def __call__(self, features: torch.Tensor, env_index: int, representation_scale=None):
+        value = self._actions[self._idx]
+        self._idx = min(self._idx + 1, len(self._actions) - 1)
+        action = torch.full((features.shape[0], 1), value, device=features.device)
+        return {"action": action}
+
+
+def test_single_asset_env_simulation_tracks_basic_metrics():
+    batch = _make_episode_batch()
+    engineer = FeatureEngineer()
+    engineer.fit([batch])
+
+    env = SingleAssetHedgingEnv(env_index=0, batch=batch, feature_engineer=engineer)
+    policy = _StepPolicy([1.0, 0.0])
+
+    result = env.simulate(policy, torch.tensor([0]), torch.device("cpu"))
+
+    torch.testing.assert_close(result.positions[0], torch.tensor([0.0, 1.0, 0.0]))
+    assert pytest.approx(result.turnover.item(), rel=1e-6) == 2.0
+    assert pytest.approx(result.max_trade.item(), rel=1e-6) == 1.0
+    assert pytest.approx(result.costs.item(), rel=1e-6) == 0.0
+    assert pytest.approx(result.option_pnl.item(), rel=1e-6) == 0.0
+    assert pytest.approx(result.underlying_pnl.item(), rel=1e-6) == -1.0
+    assert pytest.approx(result.pnl.item(), rel=1e-6) == -1.0
+    assert result.probe is None


### PR DESCRIPTION
## Summary
- add focused unit tests covering the feature engineering pipeline, hedging environment simulation, and checkpoint manager persistence
- refactor training and evaluation entry points to share environment setup utilities and support MSI feature grouping overrides from config
- restore checkpoint manifests on startup and expose MSI grouping controls via evaluation configuration defaults

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db3c928ad88331b08524445d3cec6d