### PR TITLE
Add dedicated HIRM heads and configurable penalty schedule

### DIFF
--- a/configs/train/hirm_head.yaml
+++ b/configs/train/hirm_head.yaml
@@ -34,9 +34,7 @@ logging:
   log_interval: 100
   eval_interval: 1000
 
-invariance:
-  scope: head
-  lambda_schedule:
-    type: warmup_cosine
-    warmup_steps: 20000
-    max_lambda: 1.0
+irm:
+  lambda_target: 1.0
+  schedule: linear
+  warmup_steps: 20000

--- a/configs/train/hirm_hybrid.yaml
+++ b/configs/train/hirm_hybrid.yaml
@@ -34,9 +34,7 @@ logging:
   log_interval: 100
   eval_interval: 1000
 
-invariance:
-  scope: head
-  lambda_schedule:
-    type: warmup_cosine
-    warmup_steps: 20000
-    max_lambda: 0.5
+irm:
+  lambda_target: 0.5
+  schedule: linear
+  warmup_steps: 20000

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,6 +1,14 @@
 """Model exports for invariant hedging."""
 from .policy_mlp import PolicyMLP
-from .two_head_policy import TwoHeadPolicy
 from .heads import RiskHead, RepresentationHead
+from .hirm_head import HIRMHead, irm_penalty as hirm_head_penalty
+from .hirm_hybrid import HIRMHybrid
 
-__all__ = ["PolicyMLP", "TwoHeadPolicy", "RiskHead", "RepresentationHead"]
+__all__ = [
+    "PolicyMLP",
+    "RiskHead",
+    "RepresentationHead",
+    "HIRMHead",
+    "HIRMHybrid",
+    "hirm_head_penalty",
+]

--- a/src/models/hirm_head.py
+++ b/src/models/hirm_head.py
@@ -1,0 +1,34 @@
+"""Risk-only IRM head used for HIRM-Head experiments."""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class HIRMHead(nn.Module):
+    """Risk estimator head equipped with an IRMv1 scaling parameter."""
+
+    def __init__(self, base_repr: nn.Module, risk_head: nn.Module) -> None:
+        super().__init__()
+        self.repr = base_repr
+        self.risk_head = risk_head
+        self.w = nn.Parameter(torch.ones(1))
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        """Return risk predictions for the provided features."""
+
+        phi = self.repr(features)
+        return self.risk_head(phi)
+
+
+def irm_penalty(per_env_loss: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+    """IRMv1 penalty on the provided scalar per-environment loss."""
+
+    if per_env_loss.ndim != 0:
+        per_env_loss = per_env_loss.mean()
+    grad = torch.autograd.grad(per_env_loss * (w ** 2), [w], create_graph=True)[0]
+    return torch.sum(grad ** 2)
+
+
+__all__ = ["HIRMHead", "irm_penalty"]
+

--- a/src/models/hirm_hybrid.py
+++ b/src/models/hirm_hybrid.py
@@ -1,0 +1,40 @@
+"""Hybrid risk head combining invariant and adaptive estimates."""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class HIRMHybrid(nn.Module):
+    """Two-head risk estimator with a learnable gating coefficient."""
+
+    def __init__(
+        self,
+        base_repr: nn.Module,
+        risk_head_inv: nn.Module,
+        risk_head_adapt: nn.Module,
+        *,
+        alpha_init: float = 0.0,
+        freeze_alpha: bool = False,
+    ) -> None:
+        super().__init__()
+        self.repr = base_repr
+        self.h_inv = risk_head_inv
+        self.h_adapt = risk_head_adapt
+        self.alpha = nn.Parameter(torch.tensor(alpha_init, dtype=torch.float32), requires_grad=not freeze_alpha)
+        self.w_inv = nn.Parameter(torch.ones(1))
+
+    def forward(self, features: torch.Tensor):
+        phi = self.repr(features)
+        r_inv = self.h_inv(phi)
+        r_adapt = self.h_adapt(phi)
+        gate = torch.sigmoid(self.alpha)
+        r_hat = gate * r_inv + (1 - gate) * r_adapt
+        return r_hat, r_inv, r_adapt, gate
+
+    def gate_value(self) -> torch.Tensor:
+        return torch.sigmoid(self.alpha.detach())
+
+
+__all__ = ["HIRMHybrid"]
+

--- a/tests/test_hybrid_gate_shared.py
+++ b/tests/test_hybrid_gate_shared.py
@@ -1,31 +1,22 @@
 import torch
+from torch import nn
 
-from src.models.two_head_policy import TwoHeadPolicy
+from src.models.hirm_hybrid import HIRMHybrid
+from src.models.heads import RiskHead
 
 
 def test_hybrid_gate_is_scalar_and_shared():
-    policy = TwoHeadPolicy(
-        feature_dim=5,
-        num_envs=3,
-        hidden_width=8,
-        hidden_depth=2,
-        dropout=0.0,
-        layer_norm=False,
-        representation_dim=4,
-        adapter_hidden=4,
-        max_position=2.0,
-        risk_hidden=4,
-        alpha_init=0.3,
-    )
+    risk_inv = RiskHead(4, 4)
+    risk_adapt = RiskHead(4, 4)
+    hybrid = HIRMHybrid(nn.Identity(), risk_inv, risk_adapt, alpha_init=0.3)
 
-    assert policy.alpha.shape == torch.Size([]), "Alpha parameter should be a scalar"
+    assert hybrid.alpha.shape == torch.Size([]), "Alpha parameter should be a scalar"
 
-    gate_before = policy.gate_value().item()
-    features_env0 = torch.randn(6, 5)
-    features_env1 = torch.randn(6, 5)
-    _ = policy(features_env0, env_index=0)
-    gate_after_env0 = policy.gate_value().item()
-    _ = policy(features_env1, env_index=2)
-    gate_after_env1 = policy.gate_value().item()
+    gate_before = hybrid.gate_value().item()
+    features_env0 = torch.randn(6, 4)
+    features_env1 = torch.randn(6, 4)
+    out0 = hybrid(features_env0)
+    out1 = hybrid(features_env1)
 
-    assert gate_before == gate_after_env0 == gate_after_env1, "Gate should not depend on environment"
+    assert torch.isclose(out0[-1], out1[-1]), "Gate outputs should match across calls"
+    assert gate_before == hybrid.gate_value().item(), "Gate parameter should not change during forward"


### PR DESCRIPTION
## Summary
- add dedicated `HIRMHead` and `HIRMHybrid` modules with IRMv1-style scaling parameters for the risk heads
- refactor training to apply penalties through the new heads and log the scheduled `lambda` values
- expose simple `irm` schedule settings in the HIRM configs and update the hybrid gate unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df259c506c83319848a392825e3d7f