### PR TITLE
Add Phase 2 scorecard automation and visualizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PYTHON ?= python3
 CONFIG ?= configs/experiment.yaml
 
-.PHONY: setup train evaluate reproduce lint tests smoke phase2
+.PHONY: setup train evaluate reproduce lint tests smoke phase2 phase2_scorecard
 
 setup:
 	$(PYTHON) -m pip install -r requirements.txt
@@ -36,4 +36,13 @@ smoke:
 	python3 -m src.eval --config-name=eval/smoke eval.report.checkpoint_path=$$CHECKPOINT
 
 phase2:
-	@echo "See experiments/phase2_plan.md for details."
+        @echo "See experiments/phase2_plan.md for details."
+
+.PHONY: phase2_scorecard
+phase2_scorecard:
+	python scripts/make_scorecard.py --methods ERM,ERM_reg,IRM,HIRM_Head,GroupDRO,V_REx --seeds 0..29 --split crisis --outdir runs/scorecard_export --read_only false --phase phase2 --commit_hash $$(git rev-parse --short HEAD)
+	python scripts/compute_diagnostics.py --methods ERM,ERM_reg,IRM,HIRM_Head,GroupDRO,V_REx --seeds 0..29 --train_envs low,medium --val_envs high --test_envs crisis --out runs/scorecard_export/diagnostics_all.csv --phase phase2 --commit_hash $$(git rev-parse --short HEAD)
+	python scripts/plot_cvar_violin.py --scorecard runs/scorecard_export/scorecard.csv --diagnostics runs/scorecard_export/diagnostics_all.csv --out runs/scorecard_export/figs/fig_cvar_violin.png
+	python scripts/plot_ig_vs_cvar.py --diagnostics runs/scorecard_export/diagnostics_all.csv --out runs/scorecard_export/figs/fig_ig_vs_cvar.png
+	python scripts/plot_capital_frontier.py --scorecard runs/scorecard_export/scorecard.csv --out runs/scorecard_export/figs/fig_capital_frontier.png
+	python scripts/export_tables.py --scorecard runs/scorecard_export/scorecard.csv --out_md runs/scorecard_export/table_crisis.md --out_tex runs/scorecard_export/table_crisis.tex

--- a/scripts/compute_diagnostics.py
+++ b/scripts/compute_diagnostics.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""Compute IG, WG, and MSI diagnostics across seeds and methods."""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import math
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None  # type: ignore
+
+LOGGER = logging.getLogger("compute_diagnostics")
+
+
+@dataclass
+class RunMetadata:
+    method: Optional[str]
+    seed: Optional[int]
+    path: Path
+    config_tag: Optional[str]
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s | %(message)s")
+
+
+def _require_yaml() -> None:
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to read Hydra config files")
+
+
+def _parse_methods(value: str) -> List[str]:
+    methods = [item.strip() for item in value.split(",") if item.strip()]
+    if not methods:
+        raise ValueError("No methods parsed from specification")
+    return methods
+
+
+def _parse_range(value: str) -> List[int]:
+    value = value.strip()
+    if ".." in value:
+        lo, hi = value.split("..", 1)
+        start = int(lo)
+        end = int(hi)
+        if end < start:
+            raise ValueError("Invalid range: upper bound smaller than lower bound")
+        return list(range(start, end + 1))
+    return [int(token.strip()) for token in value.split(",") if token.strip()]
+
+
+def _parse_envs(value: str) -> List[str]:
+    if not value:
+        return []
+    return [token.strip().lower() for token in value.split(",") if token.strip()]
+
+
+def _candidate_run_roots(default: Path) -> List[Path]:
+    roots = [default]
+    extra = os.environ.get("HIRM_EXTRA_RUN_DIRS")
+    if extra:
+        for token in extra.split(os.pathsep):
+            token = token.strip()
+            if token:
+                roots.append(Path(token))
+    return roots
+
+
+_METHOD_CANONICAL = {
+    "erm": "ERM",
+    "erm_reg": "ERM_reg",
+    "irm": "IRM",
+    "hirm_head": "HIRM_Head",
+    "hirm": "HIRM",
+    "groupdro": "GroupDRO",
+    "group_dro": "GroupDRO",
+    "vrex": "V_REx",
+    "v-rex": "V_REx",
+    "vrd": "V_REx",
+}
+
+
+def _canonical_method(name: object | None) -> Optional[str]:
+    if name is None:
+        return None
+    key = str(name).strip().lower()
+    return _METHOD_CANONICAL.get(key)
+
+
+def _load_yaml(path: Path) -> Mapping[str, object]:
+    if not path.exists():
+        return {}
+    _require_yaml()
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if isinstance(data, Mapping):
+        return data
+    return {}
+
+
+def _load_json(path: Path) -> Mapping[str, object]:
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except json.JSONDecodeError:
+        LOGGER.warning("Failed to parse JSON from %s", path)
+        return {}
+    if isinstance(data, Mapping):
+        return data
+    return {}
+
+
+def _extract_seed_from_config(config: Mapping[str, object]) -> Optional[int]:
+    for key in ("seed", "random_seed"):
+        if key in config:
+            try:
+                return int(config[key])
+            except (TypeError, ValueError):
+                continue
+    train_cfg = config.get("train") if isinstance(config, Mapping) else None
+    if isinstance(train_cfg, Mapping):
+        for key in ("seed", "random_seed"):
+            if key in train_cfg:
+                try:
+                    return int(train_cfg[key])
+                except (TypeError, ValueError):
+                    continue
+    runtime_cfg = config.get("runtime") if isinstance(config, Mapping) else None
+    if isinstance(runtime_cfg, Mapping) and "seed" in runtime_cfg:
+        try:
+            return int(runtime_cfg["seed"])
+        except (TypeError, ValueError):
+            pass
+    return None
+
+
+def _extract_method_from_config(config: Mapping[str, object]) -> Optional[str]:
+    model_cfg = config.get("model") if isinstance(config, Mapping) else None
+    if isinstance(model_cfg, Mapping):
+        if (method := _canonical_method(model_cfg.get("name"))):
+            return method
+        if (method := _canonical_method(model_cfg.get("objective"))):
+            return method
+    algorithm_cfg = config.get("algorithm") if isinstance(config, Mapping) else None
+    if isinstance(algorithm_cfg, Mapping):
+        if (method := _canonical_method(algorithm_cfg.get("name"))):
+            return method
+    if "method" in config:
+        return _canonical_method(config.get("method"))
+    return None
+
+
+def _iter_run_metadata(roots: Sequence[Path]) -> Iterator[RunMetadata]:
+    for root in roots:
+        if not root.exists():
+            continue
+        for config_path in root.rglob("config.yaml"):
+            run_dir = config_path.parent
+            metrics_path = run_dir / "final_metrics.json"
+            if not metrics_path.exists():
+                continue
+            config = _load_yaml(config_path)
+            method = _extract_method_from_config(config)
+            seed = _extract_seed_from_config(config)
+            tags = None
+            if isinstance(config, Mapping):
+                experiment_cfg = config.get("experiment")
+                if isinstance(experiment_cfg, Mapping):
+                    tag_values = experiment_cfg.get("tags")
+                    if isinstance(tag_values, (list, tuple)):
+                        tags = ",".join(str(val) for val in tag_values)
+                elif "tags" in config and isinstance(config["tags"], (list, tuple)):
+                    tags = ",".join(str(val) for val in config["tags"])
+            yield RunMetadata(method=method, seed=seed, path=run_dir, config_tag=tags)
+
+
+def _normalize_key(key: str) -> str:
+    return key.replace("/", "_").replace("-", "_").lower()
+
+
+_METRIC_ALIASES: Mapping[str, Tuple[str, ...]] = {
+    "es95": (
+        "es95",
+        "cvar",
+        "cvar95",
+        "cvar_95",
+        "crisis_cvar",
+        "crisis_es95",
+    ),
+    "meanpnl": (
+        "mean_pnl",
+        "mean",
+        "crisis_mean_pnl",
+    ),
+    "turnover": (
+        "turnover",
+        "crisis_turnover",
+    ),
+}
+
+
+def _find_metric(metrics: Mapping[str, object], split: str, metric: str) -> Optional[float]:
+    if not metrics:
+        return None
+    split_key = split.lower()
+    normalized = {_normalize_key(k): v for k, v in metrics.items()}
+    aliases = list(_METRIC_ALIASES.get(metric, ()))
+    candidates: List[str] = []
+    for alias in aliases:
+        candidates.extend([
+            alias,
+            f"{split_key}_{alias}",
+            f"test_{split_key}_{alias}",
+            f"test/{split_key}_{alias}",
+            f"test/{split_key}/{alias}",
+        ])
+    for cand in candidates:
+        key = _normalize_key(cand)
+        if key in normalized:
+            try:
+                return float(normalized[key])
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def _load_diagnostics_record(run_dir: Path) -> Tuple[Optional[Mapping[str, object]], float]:
+    latest_record: Optional[Mapping[str, object]] = None
+    latest_mtime = 0.0
+    for base in (run_dir, run_dir / "artifacts"):
+        jsonl_path = base / "diagnostics.jsonl"
+        if not jsonl_path.exists():
+            continue
+        try:
+            with jsonl_path.open("r", encoding="utf-8") as handle:
+                lines = [line.strip() for line in handle if line.strip()]
+        except OSError:
+            continue
+        for raw in reversed(lines):
+            try:
+                record = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(record, Mapping):
+                latest_record = record
+                latest_mtime = max(latest_mtime, jsonl_path.stat().st_mtime)
+                break
+    return latest_record, latest_mtime
+
+
+def _collect_env_values(
+    env_metrics: Mapping[str, Mapping[str, object]] | None,
+    target_names: Iterable[str],
+    expected_split: Optional[str],
+) -> List[float]:
+    if not env_metrics:
+        return []
+    names = {name.lower() for name in target_names if name}
+    values: List[float] = []
+    fallback: List[float] = []
+    for env_name, metrics in env_metrics.items():
+        if not isinstance(metrics, Mapping):
+            continue
+        split = str(metrics.get("split", "")).lower()
+        es95 = metrics.get("ES95") or metrics.get("es95")
+        if es95 is None:
+            continue
+        try:
+            es95_val = float(es95)
+        except (TypeError, ValueError):
+            continue
+        name_key = env_name.lower()
+        if names and name_key not in names:
+            if expected_split and split == expected_split:
+                fallback.append(es95_val)
+            continue
+        if expected_split and split and split != expected_split:
+            continue
+        values.append(es95_val)
+    if not values and expected_split:
+        return fallback
+    return values
+
+
+def _extract_single_env_metric(
+    env_metrics: Mapping[str, Mapping[str, object]] | None,
+    target_names: Iterable[str],
+    expected_split: Optional[str],
+) -> Optional[float]:
+    candidates = _collect_env_values(env_metrics, target_names, expected_split)
+    if candidates:
+        return candidates[0]
+    return None
+
+
+def _gap(values: Iterable[float]) -> Optional[float]:
+    vals = [float(v) for v in values if v is not None and not math.isnan(v)]
+    if not vals:
+        return None
+    return max(vals) - min(vals)
+
+
+def _max_or_nan(values: Iterable[float]) -> float:
+    vals = [float(v) for v in values if v is not None and not math.isnan(v)]
+    return max(vals) if vals else math.nan
+
+
+def _min_or_nan(values: Iterable[float]) -> float:
+    vals = [float(v) for v in values if v is not None and not math.isnan(v)]
+    return min(vals) if vals else math.nan
+
+
+def _compute_wg(train_vals: Iterable[float], test_vals: Iterable[float]) -> Optional[float]:
+    train_list = [float(v) for v in train_vals if v is not None and not math.isnan(v)]
+    test_list = [float(v) for v in test_vals if v is not None and not math.isnan(v)]
+    if not train_list or not test_list:
+        return None
+    return max(test_list) - max(train_list)
+
+
+def _empty_row(method: str, seed: int) -> Dict[str, object]:
+    return {
+        "method": method,
+        "seed": seed,
+        "ig": math.nan,
+        "wg": math.nan,
+        "msi": math.nan,
+        "es95_crisis": math.nan,
+        "meanpnl_crisis": math.nan,
+        "turnover_crisis": math.nan,
+        "es95_train_max": math.nan,
+        "es95_train_min": math.nan,
+        "es95_val_high": math.nan,
+        "commit": None,
+        "phase": None,
+        "config_tag": None,
+    }
+
+
+def _ensure_outdir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--methods", required=True, help="Comma-separated list of methods")
+    parser.add_argument("--seeds", required=True, help="Seed specification, e.g. 0..29")
+    parser.add_argument("--train_envs", required=True, help="Comma-separated training environments")
+    parser.add_argument("--val_envs", required=True, help="Comma-separated validation environments")
+    parser.add_argument("--test_envs", required=True, help="Comma-separated test environments")
+    parser.add_argument("--out", required=True, help="Output CSV path")
+    parser.add_argument("--split", default="crisis", help="Test split name for summary metrics")
+    parser.add_argument("--phase", default="phase2", help="Experiment phase label")
+    parser.add_argument("--commit_hash", default="UNKNOWN", help="Commit hash for provenance")
+    parser.add_argument("--config_tag", default=None, help="Optional config tag override")
+    parser.add_argument("--run_roots", default=None, help="Additional run directories (os.pathsep separated)")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    args = parser.parse_args(argv)
+    args.methods = _parse_methods(args.methods)
+    args.seeds = _parse_range(args.seeds)
+    args.train_envs = _parse_envs(args.train_envs)
+    args.val_envs = _parse_envs(args.val_envs)
+    args.test_envs = _parse_envs(args.test_envs)
+    return args
+
+
+def _collect_diagnostics(
+    roots: Sequence[Path],
+    methods: Sequence[str],
+    seeds: Sequence[int],
+    split: str,
+    train_envs: Sequence[str],
+    val_envs: Sequence[str],
+    test_envs: Sequence[str],
+) -> Tuple[Dict[Tuple[str, int], Dict[str, object]], Dict[str, str]]:
+    method_lookup = {method.upper(): method for method in methods}
+    seed_set = set(seeds)
+    records: Dict[Tuple[str, int], Tuple[float, Dict[str, object]]] = {}
+    config_tags: Dict[str, str] = {}
+    for meta in _iter_run_metadata(roots):
+        if meta.method is None or meta.seed is None:
+            continue
+        canonical = meta.method.upper()
+        method = method_lookup.get(canonical)
+        if method is None:
+            continue
+        if meta.seed not in seed_set:
+            continue
+        final_metrics = _load_json(meta.path / "final_metrics.json")
+        diag_record, diag_mtime = _load_diagnostics_record(meta.path)
+        metrics_mtime = (meta.path / "final_metrics.json").stat().st_mtime if (meta.path / "final_metrics.json").exists() else meta.path.stat().st_mtime
+        combined_mtime = max(metrics_mtime, diag_mtime)
+        env_metrics = diag_record.get("env_metrics") if isinstance(diag_record, Mapping) else None
+        train_vals = _collect_env_values(env_metrics, train_envs, "train")
+        test_vals = _collect_env_values(env_metrics, test_envs, "test")
+        ig = None
+        if isinstance(diag_record, Mapping):
+            ig = diag_record.get("IG", {}).get("ES95") if isinstance(diag_record.get("IG"), Mapping) else None
+        if ig is None:
+            ig = _gap(train_vals)
+        wg = None
+        if isinstance(diag_record, Mapping):
+            wg = diag_record.get("WG", {}).get("ES95") if isinstance(diag_record.get("WG"), Mapping) else None
+        if wg is None:
+            wg = _compute_wg(train_vals, test_vals)
+        msi = None
+        if isinstance(diag_record, Mapping):
+            msi_obj = diag_record.get("MSI")
+            if isinstance(msi_obj, Mapping):
+                msi = msi_obj.get("value")
+        train_max = _max_or_nan(train_vals)
+        train_min = _min_or_nan(train_vals)
+        val_high = _extract_single_env_metric(env_metrics, val_envs, "val")
+        crisis_es = _extract_single_env_metric(env_metrics, test_envs, "test")
+        if crisis_es is None:
+            crisis_es = _find_metric(final_metrics, split, "es95")
+        mean_pnl = _find_metric(final_metrics, split, "meanpnl")
+        turnover = _find_metric(final_metrics, split, "turnover")
+        row = {
+            "method": method,
+            "seed": int(meta.seed),
+            "ig": float(ig) if ig is not None else math.nan,
+            "wg": float(wg) if wg is not None else math.nan,
+            "msi": float(msi) if msi is not None else math.nan,
+            "es95_crisis": float(crisis_es) if crisis_es is not None else math.nan,
+            "meanpnl_crisis": float(mean_pnl) if mean_pnl is not None else math.nan,
+            "turnover_crisis": float(turnover) if turnover is not None else math.nan,
+            "es95_train_max": train_max,
+            "es95_train_min": train_min,
+            "es95_val_high": float(val_high) if val_high is not None else math.nan,
+            "config_tag": meta.config_tag,
+        }
+        key = (method, int(meta.seed))
+        existing = records.get(key)
+        if existing is None or combined_mtime >= existing[0]:
+            records[key] = (combined_mtime, row)
+        if meta.config_tag and method not in config_tags:
+            config_tags[method] = meta.config_tag
+    resolved = {key: value for key, (mtime, value) in records.items()}
+    return resolved, config_tags
+
+
+def _write_csv(path: Path, rows: Sequence[Mapping[str, object]]) -> None:
+    fieldnames = [
+        "method",
+        "seed",
+        "ig",
+        "wg",
+        "msi",
+        "es95_crisis",
+        "meanpnl_crisis",
+        "turnover_crisis",
+        "es95_train_max",
+        "es95_train_min",
+        "es95_val_high",
+        "commit",
+        "phase",
+        "config_tag",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    _setup_logging(args.verbose)
+    run_roots = _candidate_run_roots(Path("runs"))
+    if args.run_roots:
+        for token in args.run_roots.split(os.pathsep):
+            token = token.strip()
+            if token:
+                run_roots.append(Path(token))
+    LOGGER.info("Scanning diagnostic runs under: %s", ", ".join(str(p) for p in run_roots))
+    diag_records, config_tags = _collect_diagnostics(
+        run_roots,
+        args.methods,
+        args.seeds,
+        args.split,
+        args.train_envs,
+        args.val_envs,
+        args.test_envs,
+    )
+    rows: List[Dict[str, object]] = []
+    for method in args.methods:
+        for seed in args.seeds:
+            key = (method, seed)
+            row = diag_records.get(key, _empty_row(method, seed))
+            row = dict(row)
+            row["commit"] = args.commit_hash
+            row["phase"] = args.phase
+            if row.get("config_tag"):
+                pass
+            elif method in config_tags:
+                row["config_tag"] = config_tags[method]
+            elif args.config_tag:
+                row["config_tag"] = args.config_tag
+            rows.append(row)
+    rows.sort(key=lambda item: (item["method"], item["seed"]))
+    out_path = Path(args.out)
+    _ensure_outdir(out_path)
+    _write_csv(out_path, rows)
+    LOGGER.info("Diagnostics written to %s", out_path)
+    meta = {
+        "commit": args.commit_hash,
+        "phase": args.phase,
+        "split": args.split,
+        "methods": args.methods,
+        "seeds": args.seeds,
+        "train_envs": args.train_envs,
+        "val_envs": args.val_envs,
+        "test_envs": args.test_envs,
+        "config_tags": config_tags,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    meta_path = out_path.with_suffix(".meta.json")
+    with meta_path.open("w", encoding="utf-8") as handle:
+        json.dump(meta, handle, indent=2)
+    LOGGER.debug("Metadata written to %s", meta_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_tables.py
+++ b/scripts/export_tables.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Export scorecard summaries to Markdown and LaTeX tables."""
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import math
+from pathlib import Path
+from typing import Dict, List, Mapping, Sequence
+
+LOGGER = logging.getLogger("export_tables")
+
+REQUIRED_COLUMNS = [
+    "method",
+    "n_seeds",
+    "es95_mean",
+    "es95_ci_low",
+    "es95_ci_high",
+    "meanpnl_mean",
+    "meanpnl_ci_low",
+    "meanpnl_ci_high",
+    "turnover_mean",
+    "turnover_ci_low",
+    "turnover_ci_high",
+    "d_es95_vs_ERM_pct",
+    "d_meanpnl_vs_ERM_pct",
+    "d_turnover_vs_ERM_pct",
+]
+
+MARKDOWN_HEADERS = [
+    "Method",
+    "Seeds",
+    "ES95 (95% CI)",
+    "Mean PnL (95% CI)",
+    "Turnover (95% CI)",
+    "ΔES95 vs ERM (%)",
+    "ΔMeanPnL vs ERM (%)",
+    "ΔTurnover vs ERM (%)",
+]
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s | %(message)s")
+
+
+def _load_rows(path: Path) -> List[Dict[str, object]]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    with path.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        rows = [dict(row) for row in reader]
+    return rows
+
+
+def _validate_columns(rows: Sequence[Mapping[str, object]]) -> None:
+    if not rows:
+        raise ValueError("Scorecard is empty; cannot export tables")
+    missing = [col for col in REQUIRED_COLUMNS if col not in rows[0]]
+    if missing:
+        raise KeyError(f"Scorecard missing required columns: {missing}")
+
+
+def _to_float(value: object) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return math.nan
+
+
+def _format_ci(mean: object, low: object, high: object) -> str:
+    mean_val = _to_float(mean)
+    low_val = _to_float(low)
+    high_val = _to_float(high)
+    if any(math.isnan(v) for v in (mean_val, low_val, high_val)):
+        return "NA"
+    return f"{mean_val:.4f} [{low_val:.4f}, {high_val:.4f}]"
+
+
+def _format_pct(value: object) -> str:
+    val = _to_float(value)
+    if math.isnan(val):
+        return "NA"
+    return f"{val:.2f}%"
+
+
+def _markdown_table(rows: Sequence[Mapping[str, object]]) -> str:
+    table_rows: List[List[str]] = [MARKDOWN_HEADERS, ["---"] * len(MARKDOWN_HEADERS)]
+    for row in rows:
+        table_rows.append(
+            [
+                str(row.get("method", "")),
+                str(row.get("n_seeds", "")),
+                _format_ci(row.get("es95_mean"), row.get("es95_ci_low"), row.get("es95_ci_high")),
+                _format_ci(row.get("meanpnl_mean"), row.get("meanpnl_ci_low"), row.get("meanpnl_ci_high")),
+                _format_ci(row.get("turnover_mean"), row.get("turnover_ci_low"), row.get("turnover_ci_high")),
+                _format_pct(row.get("d_es95_vs_ERM_pct")),
+                _format_pct(row.get("d_meanpnl_vs_ERM_pct")),
+                _format_pct(row.get("d_turnover_vs_ERM_pct")),
+            ]
+        )
+    return "\n".join("| " + " | ".join(row) + " |" for row in table_rows)
+
+
+def _latex_table(rows: Sequence[Mapping[str, object]]) -> str:
+    header = r"\begin{tabular}{lrrrrrrr}\toprule"
+    lines = [header]
+    lines.append(
+        r"Method & Seeds & ES95 (95\% CI) & Mean PnL (95\% CI) & Turnover (95\% CI) & "
+        r"\(\Delta\)ES95 vs ERM (\%) & \(\Delta\)MeanPnL vs ERM (\%) & \(\Delta\)Turnover vs ERM (\%) \\"
+    )
+    lines.append(r"\midrule")
+    for row in rows:
+        fields = [
+            str(row.get("method", "")),
+            str(row.get("n_seeds", "")),
+            _format_ci(row.get("es95_mean"), row.get("es95_ci_low"), row.get("es95_ci_high")),
+            _format_ci(row.get("meanpnl_mean"), row.get("meanpnl_ci_low"), row.get("meanpnl_ci_high")),
+            _format_ci(row.get("turnover_mean"), row.get("turnover_ci_low"), row.get("turnover_ci_high")),
+            _format_pct(row.get("d_es95_vs_ERM_pct")),
+            _format_pct(row.get("d_meanpnl_vs_ERM_pct")),
+            _format_pct(row.get("d_turnover_vs_ERM_pct")),
+        ]
+        lines.append(" & ".join(fields) + r" \\")
+    lines.append(r"\bottomrule\end{tabular}")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scorecard", required=True, help="Input scorecard CSV")
+    parser.add_argument("--out_md", required=True, help="Markdown output path")
+    parser.add_argument("--out_tex", required=True, help="LaTeX output path")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    return parser.parse_args(argv)
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    _setup_logging(args.verbose)
+    rows = _load_rows(Path(args.scorecard))
+    _validate_columns(rows)
+    rows.sort(key=lambda item: item.get("method", ""))
+
+    md_path = Path(args.out_md)
+    tex_path = Path(args.out_tex)
+    _ensure_parent(md_path)
+    _ensure_parent(tex_path)
+
+    markdown = _markdown_table(rows)
+    with md_path.open("w", encoding="utf-8") as handle:
+        handle.write(markdown + "\n")
+    LOGGER.info("Wrote Markdown table to %s", md_path)
+
+    latex = _latex_table(rows)
+    with tex_path.open("w", encoding="utf-8") as handle:
+        handle.write(latex + "\n")
+    LOGGER.info("Wrote LaTeX table to %s", tex_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/make_scorecard.py
+++ b/scripts/make_scorecard.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+"""Aggregate evaluation metrics into a Phase-2 scorecard."""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import math
+import os
+import statistics
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+except ImportError as exc:  # pragma: no cover - provide helpful error later
+    yaml = None  # type: ignore
+
+LOGGER = logging.getLogger("make_scorecard")
+
+_METHOD_CANONICAL = {
+    "erm": "ERM",
+    "erm_reg": "ERM_reg",
+    "irm": "IRM",
+    "hirm_head": "HIRM_Head",
+    "hirm": "HIRM",
+    "groupdro": "GroupDRO",
+    "group_dro": "GroupDRO",
+    "vrd": "V_REx",
+    "v-rex": "V_REx",
+    "vrex": "V_REx",
+}
+
+_METRIC_ALIASES: Mapping[str, Tuple[str, ...]] = {
+    "es95": (
+        "es95",
+        "cvar",
+        "cvar95",
+        "cvar_95",
+        "cv_95",
+        "cvar95",
+        "cvar95",
+        "crisis_cvar",
+        "crisis_es95",
+        "risk/cvar",
+    ),
+    "meanpnl": (
+        "mean",
+        "mean_pnl",
+        "meanpnL",
+        "avg_pnl",
+        "crisis_mean_pnl",
+        "pnl_mean",
+    ),
+    "turnover": (
+        "turnover",
+        "avg_turnover",
+        "crisis_turnover",
+    ),
+}
+
+_SCORECARD_COLUMNS: Tuple[str, ...] = (
+    "method",
+    "split",
+    "n_seeds",
+    "es95_mean",
+    "es95_ci_low",
+    "es95_ci_high",
+    "meanpnl_mean",
+    "meanpnl_ci_low",
+    "meanpnl_ci_high",
+    "turnover_mean",
+    "turnover_ci_low",
+    "turnover_ci_high",
+    "d_es95_vs_ERM_pct",
+    "d_meanpnl_vs_ERM_pct",
+    "d_turnover_vs_ERM_pct",
+    "commit",
+    "phase",
+    "config_tag",
+    "timestamp",
+)
+
+
+@dataclass
+class MetricRecord:
+    method: str
+    seed: int
+    split: str
+    es95: float
+    meanpnl: float
+    turnover: float
+    source_dir: Path
+    modified: float
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s | %(message)s")
+
+
+def _require_yaml() -> None:
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to run this script")
+
+
+def _parse_methods(value: str) -> List[str]:
+    methods = [item.strip() for item in value.split(",") if item.strip()]
+    if not methods:
+        raise ValueError("At least one method must be provided")
+    return methods
+
+
+def _parse_seeds(value: str) -> List[int]:
+    value = value.strip()
+    if not value:
+        raise ValueError("Seed specification must be non-empty")
+    if ".." in value:
+        lo, hi = value.split("..", 1)
+        start = int(lo)
+        end = int(hi)
+        if end < start:
+            raise ValueError("Invalid seed range: upper bound smaller than lower bound")
+        return list(range(start, end + 1))
+    seeds: List[int] = []
+    for token in value.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        seeds.append(int(token))
+    if not seeds:
+        raise ValueError("No seeds parsed from specification")
+    return seeds
+
+
+def _str_to_bool(value: str) -> bool:
+    lowered = value.lower()
+    if lowered in {"true", "t", "1", "yes", "y"}:
+        return True
+    if lowered in {"false", "f", "0", "no", "n"}:
+        return False
+    raise ValueError(f"Unable to parse boolean value from '{value}'")
+
+
+def _t_critical(df: int, confidence: float = 0.95) -> float:
+    if df <= 0:
+        return 0.0
+    alpha = 1.0 - confidence
+    try:  # pragma: no cover - prefer SciPy when available
+        from scipy import stats
+
+        return float(stats.t.ppf(1.0 - alpha / 2.0, df))
+    except Exception:
+        from statistics import NormalDist
+
+        return float(NormalDist().inv_cdf(1.0 - alpha / 2.0))
+
+
+def _mean(values: Sequence[float]) -> float:
+    if not values:
+        return math.nan
+    return float(statistics.fmean(values))
+
+
+def _std(values: Sequence[float]) -> float:
+    n = len(values)
+    if n <= 1:
+        return 0.0 if n == 1 else math.nan
+    mu = _mean(values)
+    variance = sum((x - mu) ** 2 for x in values) / (n - 1)
+    return math.sqrt(max(variance, 0.0))
+
+
+def _confidence_interval(values: Sequence[float], confidence: float = 0.95) -> Tuple[float, float, float]:
+    if not values:
+        return math.nan, math.nan, math.nan
+    mean_val = _mean(values)
+    n = len(values)
+    if n <= 1:
+        return mean_val, mean_val, mean_val
+    std_val = _std(values)
+    if math.isnan(std_val):
+        return mean_val, math.nan, math.nan
+    se = std_val / math.sqrt(n)
+    margin = _t_critical(n - 1, confidence) * se
+    return mean_val, mean_val - margin, mean_val + margin
+
+
+def _normalize_key(key: str) -> str:
+    return key.replace("/", "_").replace("-", "_").lower()
+
+
+def _find_metric(metrics: Mapping[str, object], split: str, metric: str) -> Optional[float]:
+    split_key = split.lower()
+    canonical = _METRIC_ALIASES.get(metric, ())
+    candidates = []
+    for alias in canonical:
+        candidates.append(alias)
+        candidates.append(f"{split_key}_{alias}")
+        candidates.append(f"{split_key}{alias}")
+        candidates.append(f"{split_key}/{alias}")
+        candidates.append(f"test_{split_key}_{alias}")
+        candidates.append(f"test/{split_key}_{alias}")
+        candidates.append(f"test/{split_key}/{alias}")
+        candidates.append(f"test_{split_key}/{alias}")
+        candidates.append(f"{split_key}_{alias}_mean")
+    normalized = { _normalize_key(k): v for k, v in metrics.items() }
+    for cand in candidates:
+        value = normalized.get(_normalize_key(cand))
+        if value is not None:
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def _load_json(path: Path) -> Dict[str, object]:
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except json.JSONDecodeError:
+        LOGGER.warning("Failed to parse JSON from %s", path)
+        return {}
+
+
+def _load_yaml(path: Path) -> Mapping[str, object]:
+    if not path.exists():
+        return {}
+    _require_yaml()
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if isinstance(data, Mapping):
+        return data
+    return {}
+
+
+def _candidate_run_roots(default: Path) -> List[Path]:
+    roots = [default]
+    extra = os.environ.get("HIRM_EXTRA_RUN_DIRS")
+    if extra:
+        for token in extra.split(os.pathsep):
+            token = token.strip()
+            if token:
+                roots.append(Path(token))
+    return roots
+
+
+def _canonical_method(name: str | None) -> Optional[str]:
+    if not name:
+        return None
+    key = str(name).strip().lower()
+    return _METHOD_CANONICAL.get(key)
+
+
+def _extract_method_from_config(config: Mapping[str, object]) -> Optional[str]:
+    model = config.get("model") if isinstance(config, Mapping) else None
+    if isinstance(model, Mapping):
+        if (method := _canonical_method(model.get("name"))):
+            return method
+        if (method := _canonical_method(model.get("objective"))):
+            return method
+    algo = config.get("algorithm") if isinstance(config, Mapping) else None
+    if isinstance(algo, Mapping):
+        if (method := _canonical_method(algo.get("name"))):
+            return method
+    if "method" in config:
+        return _canonical_method(config.get("method"))
+    return None
+
+
+def _extract_seed_from_config(config: Mapping[str, object]) -> Optional[int]:
+    for key in ("seed", "random_seed"):
+        if key in config:
+            try:
+                return int(config[key])
+            except (TypeError, ValueError):
+                continue
+    train_cfg = config.get("train") if isinstance(config, Mapping) else None
+    if isinstance(train_cfg, Mapping):
+        for key in ("seed", "random_seed"):
+            if key in train_cfg:
+                try:
+                    return int(train_cfg[key])
+                except (TypeError, ValueError):
+                    continue
+    runtime_cfg = config.get("runtime") if isinstance(config, Mapping) else None
+    if isinstance(runtime_cfg, Mapping) and "seed" in runtime_cfg:
+        try:
+            return int(runtime_cfg["seed"])
+        except (TypeError, ValueError):
+            pass
+    return None
+
+
+@dataclass
+class RunMetadata:
+    method: Optional[str]
+    seed: Optional[int]
+    path: Path
+    config_tag: Optional[str]
+
+
+def _iter_run_metadata(roots: Sequence[Path]) -> Iterator[RunMetadata]:
+    for root in roots:
+        if not root.exists():
+            continue
+        for config_path in root.rglob("config.yaml"):
+            run_dir = config_path.parent
+            metrics_path = run_dir / "final_metrics.json"
+            if not metrics_path.exists():
+                continue
+            config = _load_yaml(config_path)
+            method = _extract_method_from_config(config)
+            seed = _extract_seed_from_config(config)
+            tags = None
+            if isinstance(config, Mapping):
+                experiment = config.get("experiment")
+                if isinstance(experiment, Mapping):
+                    tags_val = experiment.get("tags")
+                    if isinstance(tags_val, (list, tuple)):
+                        tags = ",".join(str(t) for t in tags_val)
+                elif "tags" in config and isinstance(config["tags"], (list, tuple)):
+                    tags = ",".join(str(t) for t in config["tags"])
+            yield RunMetadata(method=method, seed=seed, path=run_dir, config_tag=tags)
+
+
+def _collect_metrics(roots: Sequence[Path], methods: Sequence[str], seeds: Sequence[int], split: str) -> Tuple[List[MetricRecord], Dict[str, str]]:
+    method_set = {m.upper(): m for m in methods}
+    seeds_set = set(seeds)
+    best: Dict[Tuple[str, int], MetricRecord] = {}
+    config_tags: Dict[str, str] = {}
+    for meta in _iter_run_metadata(roots):
+        if meta.method is None or meta.seed is None:
+            continue
+        canonical_method = meta.method
+        target_method = method_set.get(canonical_method.upper())
+        if target_method is None:
+            continue
+        if meta.seed not in seeds_set:
+            continue
+        metrics_path = meta.path / "final_metrics.json"
+        metrics = _load_json(metrics_path)
+        es95 = _find_metric(metrics, split, "es95")
+        meanpnl = _find_metric(metrics, split, "meanpnl")
+        turnover = _find_metric(metrics, split, "turnover")
+        if es95 is None or meanpnl is None or turnover is None:
+            LOGGER.debug("Missing metrics for %s seed=%s at %s", canonical_method, meta.seed, meta.path)
+            continue
+        modified = metrics_path.stat().st_mtime if metrics_path.exists() else meta.path.stat().st_mtime
+        record = MetricRecord(
+            method=target_method,
+            seed=int(meta.seed),
+            split=split,
+            es95=float(es95),
+            meanpnl=float(meanpnl),
+            turnover=float(turnover),
+            source_dir=meta.path,
+            modified=modified,
+        )
+        key = (target_method, int(meta.seed))
+        existing = best.get(key)
+        if existing is None or modified >= existing.modified:
+            best[key] = record
+        if meta.config_tag and target_method not in config_tags:
+            config_tags[target_method] = meta.config_tag
+    records = list(best.values())
+    records.sort(key=lambda rec: (rec.method, rec.seed))
+    return records, config_tags
+
+
+def _pivot_by_method(records: Iterable[MetricRecord]) -> Dict[str, List[MetricRecord]]:
+    acc: Dict[str, List[MetricRecord]] = {}
+    for record in records:
+        acc.setdefault(record.method, []).append(record)
+    return acc
+
+
+def _format_ci(mean: float, lo: float, hi: float) -> str:
+    if any(math.isnan(v) for v in (mean, lo, hi)):
+        return "NA"
+    spread = (hi - lo) / 2.0
+    return f"{mean:.4f} ± {spread:.4f}"
+
+
+def _relative_delta(target: float, baseline: float) -> float:
+    if baseline == 0 or math.isclose(baseline, 0.0, abs_tol=1e-12):
+        return math.nan
+    return (target - baseline) / baseline * 100.0
+
+
+def _compute_deltas_from_records(
+    grouped: Mapping[str, Sequence[MetricRecord]],
+    baseline: str,
+) -> Dict[str, Dict[str, float]]:
+    baseline_records = grouped.get(baseline)
+    if not baseline_records:
+        return {}
+    baseline_by_seed = {record.seed: record for record in baseline_records}
+
+    def _stats(records: Sequence[MetricRecord], seeds: Iterable[int], attr: str) -> Optional[float]:
+        values = [getattr(record, attr) for record in records if record.seed in seeds]
+        return _mean(values) if values else None
+
+    results: Dict[str, Dict[str, float]] = {}
+    for method, records in grouped.items():
+        shared_seeds = sorted(set(record.seed for record in records) & baseline_by_seed.keys())
+        base_es95_values = [baseline_by_seed[s].es95 for s in shared_seeds if s in baseline_by_seed]
+        base_meanpnl_values = [baseline_by_seed[s].meanpnl for s in shared_seeds if s in baseline_by_seed]
+        base_turnover_values = [baseline_by_seed[s].turnover for s in shared_seeds if s in baseline_by_seed]
+        base_es95_mean = _mean(base_es95_values) if base_es95_values else None
+        base_meanpnl_mean = _mean(base_meanpnl_values) if base_meanpnl_values else None
+        base_turnover_mean = _mean(base_turnover_values) if base_turnover_values else None
+        es95_mean = _stats(records, shared_seeds, "es95")
+        meanpnl_mean = _stats(records, shared_seeds, "meanpnl")
+        turnover_mean = _stats(records, shared_seeds, "turnover")
+        results[method] = {
+            "d_es95_vs_ERM_pct": _relative_delta(es95_mean, base_es95_mean) if es95_mean is not None and base_es95_mean is not None else math.nan,
+            "d_meanpnl_vs_ERM_pct": _relative_delta(meanpnl_mean, base_meanpnl_mean) if meanpnl_mean is not None and base_meanpnl_mean is not None else math.nan,
+            "d_turnover_vs_ERM_pct": _relative_delta(turnover_mean, base_turnover_mean) if turnover_mean is not None and base_turnover_mean is not None else math.nan,
+        }
+    return results
+
+
+def _ensure_outdir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _write_scorecard(path: Path, rows: Sequence[Mapping[str, object]]) -> None:
+    if not rows:
+        LOGGER.warning("No rows to write to %s", path)
+        return
+    fieldnames = list(_SCORECARD_COLUMNS)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _write_markdown(path: Path, rows: Sequence[Mapping[str, object]]) -> None:
+    if not rows:
+        return
+    headers = [
+        "Method",
+        "Seeds",
+        "ES95",
+        "Mean PnL",
+        "Turnover",
+        "ΔES95 vs ERM (%)",
+        "ΔMeanPnL vs ERM (%)",
+        "ΔTurnover vs ERM (%)",
+    ]
+    def format_row(row: Mapping[str, object]) -> List[str]:
+        return [
+            str(row.get("method", "")),
+            str(row.get("n_seeds", "0")),
+            _format_ci(row.get("es95_mean", math.nan), row.get("es95_ci_low", math.nan), row.get("es95_ci_high", math.nan)),
+            _format_ci(row.get("meanpnl_mean", math.nan), row.get("meanpnl_ci_low", math.nan), row.get("meanpnl_ci_high", math.nan)),
+            _format_ci(row.get("turnover_mean", math.nan), row.get("turnover_ci_low", math.nan), row.get("turnover_ci_high", math.nan)),
+            _format_percent(row.get("d_es95_vs_ERM_pct")),
+            _format_percent(row.get("d_meanpnl_vs_ERM_pct")),
+            _format_percent(row.get("d_turnover_vs_ERM_pct")),
+        ]
+
+    table_rows = [headers, ["---"] * len(headers)]
+    for row in rows:
+        table_rows.append(format_row(row))
+    with path.open("w", encoding="utf-8") as handle:
+        for row in table_rows:
+            handle.write("| " + " | ".join(row) + " |\n")
+
+
+def _format_percent(value: object) -> str:
+    try:
+        val = float(value)
+    except (TypeError, ValueError):
+        return "NA"
+    if math.isnan(val):
+        return "NA"
+    return f"{val:.2f}%"
+
+
+def _find_latest_checkpoint(run_dir: Path) -> Optional[Path]:
+    checkpoints_dir = run_dir / "checkpoints"
+    if not checkpoints_dir.exists():
+        return None
+    checkpoints = sorted(checkpoints_dir.glob("checkpoint_*.pt"))
+    if not checkpoints:
+        return None
+    return checkpoints[-1]
+
+
+def _launch_evaluation(method: str, seed: int, run: MetricRecord, args: argparse.Namespace) -> None:
+    LOGGER.info("Would evaluate method %s seed %s using existing checkpoint at %s", method, seed, run.source_dir)
+    # Placeholder for evaluation launch - actual invocation depends on experiment specifics.
+
+
+def _maybe_run_evaluations(records: List[MetricRecord], args: argparse.Namespace) -> None:
+    if args.read_only:
+        return
+    grouped = _pivot_by_method(records)
+    for method, method_records in grouped.items():
+        for record in method_records:
+            _launch_evaluation(method, record.seed, record, args)
+
+
+def _aggregate(records: Sequence[MetricRecord]) -> Tuple[List[Mapping[str, object]], Dict[str, Dict[str, object]]]:
+    grouped = _pivot_by_method(records)
+    stats_by_method: Dict[str, Dict[str, object]] = {}
+    method_rows: List[Mapping[str, object]] = []
+    for method, entries in sorted(grouped.items()):
+        es95_values = [entry.es95 for entry in entries]
+        meanpnl_values = [entry.meanypnl for entry in entries]
+        turnover_values = [entry.turnover for entry in entries]
+        es95_mean, es95_low, es95_high = _confidence_interval(es95_values)
+        meanpnl_mean, meanpnl_low, meanpnl_high = _confidence_interval(meanpnl_values)
+        turnover_mean, turnover_low, turnover_high = _confidence_interval(turnover_values)
+        stats = {
+            "method": method,
+            "n_seeds": len(entries),
+            "es95_mean": es95_mean,
+            "es95_ci_low": es95_low,
+            "es95_ci_high": es95_high,
+            "meanpnl_mean": meanpnl_mean,
+            "meanpnl_ci_low": meanpnl_low,
+            "meanpnl_ci_high": meanpnl_high,
+            "turnover_mean": turnover_mean,
+            "turnover_ci_low": turnover_low,
+            "turnover_ci_high": turnover_high,
+        }
+        stats_by_method[method] = stats
+        method_rows.append(stats)
+    return method_rows, stats_by_method
+
+
+def _empty_stats_row(method: str) -> Dict[str, object]:
+    return {
+        "method": method,
+        "n_seeds": 0,
+        "es95_mean": math.nan,
+        "es95_ci_low": math.nan,
+        "es95_ci_high": math.nan,
+        "meanpnl_mean": math.nan,
+        "meanpnl_ci_low": math.nan,
+        "meanpnl_ci_high": math.nan,
+        "turnover_mean": math.nan,
+        "turnover_ci_low": math.nan,
+        "turnover_ci_high": math.nan,
+        "d_es95_vs_ERM_pct": math.nan,
+        "d_meanpnl_vs_ERM_pct": math.nan,
+        "d_turnover_vs_ERM_pct": math.nan,
+        "commit": None,
+        "phase": None,
+        "config_tag": None,
+        "timestamp": None,
+        "split": None,
+    }
+
+
+def _build_params_json(args: argparse.Namespace, config_tags: Mapping[str, str], records: Sequence[MetricRecord]) -> Dict[str, object]:
+    seeds_by_method: Dict[str, List[int]] = {}
+    for record in records:
+        seeds_by_method.setdefault(record.method, []).append(record.seed)
+    for method, seeds in seeds_by_method.items():
+        seeds_by_method[method] = sorted(set(seeds))
+    for method in args.methods:
+        seeds_by_method.setdefault(method, [])
+    params = {
+        "commit": args.commit_hash,
+        "phase": args.phase,
+        "split": args.split,
+        "seeds_requested": args.seeds,
+        "methods": args.methods,
+        "seed_coverage": seeds_by_method,
+        "config_tags": config_tags,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "config_tag_override": args.config_tag,
+    }
+    return params
+
+
+def _apply_metadata(rows: List[MutableMapping[str, object]], params: Mapping[str, object], config_tags: Mapping[str, str]) -> None:
+    commit = params.get("commit")
+    phase = params.get("phase")
+    timestamp = params.get("timestamp")
+    for row in rows:
+        method = row.get("method")
+        row["commit"] = commit
+        row["phase"] = phase
+        row["timestamp"] = timestamp
+        if method in config_tags:
+            row["config_tag"] = config_tags[method]
+        elif params.get("config_tag_override"):
+            row["config_tag"] = params["config_tag_override"]
+        else:
+            row.setdefault("config_tag", None)
+        row["split"] = params.get("split")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--methods", required=True, help="Comma-separated list of method identifiers")
+    parser.add_argument("--seeds", required=True, help="Seed specification, e.g. 0..29")
+    parser.add_argument("--split", required=True, help="Evaluation split name (e.g. crisis)")
+    parser.add_argument("--outdir", required=True, help="Directory where scorecard artifacts will be stored")
+    parser.add_argument("--read_only", default="true", help="Whether to skip launching evaluations (true/false)")
+    parser.add_argument("--phase", required=True, help="Experiment phase label")
+    parser.add_argument("--commit_hash", required=True, help="Commit hash for provenance")
+    parser.add_argument("--config_tag", default=None, help="Optional config tag override for params.json")
+    parser.add_argument("--run_roots", default=None, help="Optional additional run directories (os.pathsep separated)")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    args = parser.parse_args(argv)
+    args.methods = _parse_methods(args.methods)
+    args.seeds = _parse_seeds(args.seeds)
+    args.read_only = _str_to_bool(str(args.read_only))
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    _setup_logging(args.verbose)
+    run_roots = _candidate_run_roots(Path("runs"))
+    if args.run_roots:
+        for token in args.run_roots.split(os.pathsep):
+            token = token.strip()
+            if token:
+                run_roots.append(Path(token))
+    LOGGER.info("Scanning run directories: %s", ", ".join(str(p) for p in run_roots))
+    records, config_tags = _collect_metrics(run_roots, args.methods, args.seeds, args.split)
+    config_tags = dict(config_tags)
+    if args.config_tag:
+        for method in args.methods:
+            config_tags.setdefault(method, args.config_tag)
+    if not records:
+        LOGGER.warning("No metrics found for requested configuration")
+    _maybe_run_evaluations(records, args)
+    grouped = _pivot_by_method(records)
+    rows, _ = _aggregate(records)
+    if not rows:
+        LOGGER.error("Scorecard generation failed: no aggregated rows")
+        return 1
+    deltas = _compute_deltas_from_records(grouped, "ERM")
+    rows = [dict(row) for row in rows]
+    for row in rows:
+        method = row.get("method")
+        if method in deltas:
+            row.update(deltas[method])
+        else:
+            row.setdefault("d_es95_vs_ERM_pct", math.nan)
+            row.setdefault("d_meanpnl_vs_ERM_pct", math.nan)
+            row.setdefault("d_turnover_vs_ERM_pct", math.nan)
+    existing_methods = {row.get("method") for row in rows}
+    for method in args.methods:
+        if method not in existing_methods:
+            rows.append(_empty_stats_row(method))
+    params = _build_params_json(args, config_tags, records)
+    _apply_metadata(rows, params, config_tags)
+    outdir = Path(args.outdir)
+    _ensure_outdir(outdir)
+    scorecard_path = outdir / "scorecard.csv"
+    _write_scorecard(scorecard_path, rows)
+    markdown_path = outdir / "table_crisis.md"
+    _write_markdown(markdown_path, rows)
+    params_path = outdir / "params.json"
+    with params_path.open("w", encoding="utf-8") as handle:
+        json.dump(params, handle, indent=2)
+    LOGGER.info("Scorecard written to %s", scorecard_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plot_capital_frontier.py
+++ b/scripts/plot_capital_frontier.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Visualize the capital-efficiency frontier across methods."""
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+LOGGER = logging.getLogger("plot_capital_frontier")
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s | %(message)s")
+
+
+def _ensure_outdir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scorecard", required=True, help="Path to scorecard.csv")
+    parser.add_argument("--out", required=True, help="Output image path")
+    parser.add_argument("--notional", type=float, default=1.0, help="Notional scaling (unused placeholder)")
+    parser.add_argument("--dpi", type=int, default=200, help="Output figure DPI")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    return parser.parse_args(argv)
+
+
+def _load_scorecard(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return pd.read_csv(path)
+
+
+def _pareto_front(points: List[Tuple[str, float, float]]) -> List[str]:
+    dominant: List[str] = []
+    for name_i, risk_i, pnl_i in points:
+        if math.isnan(risk_i) or math.isnan(pnl_i):
+            continue
+        dominated = False
+        for name_j, risk_j, pnl_j in points:
+            if name_i == name_j:
+                continue
+            if math.isnan(risk_j) or math.isnan(pnl_j):
+                continue
+            better_or_equal_risk = risk_j <= risk_i + 1e-9
+            better_or_equal_pnl = pnl_j >= pnl_i - 1e-9
+            strictly_better = (risk_j < risk_i - 1e-9) or (pnl_j > pnl_i + 1e-9)
+            if better_or_equal_risk and better_or_equal_pnl and strictly_better:
+                dominated = True
+                break
+        if not dominated:
+            dominant.append(name_i)
+    return dominant
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    _setup_logging(args.verbose)
+    df = _load_scorecard(Path(args.scorecard))
+    required = {"method", "es95_mean", "meanpnl_mean", "turnover_mean", "n_seeds"}
+    if not required.issubset(df.columns):
+        raise KeyError("scorecard CSV missing required columns")
+    df = df.copy()
+    df["abs_es95"] = df["es95_mean"].abs()
+    df = df[df["n_seeds"] > 0]
+    if df.empty:
+        LOGGER.error("Scorecard does not contain any methods with valid seeds")
+        return 1
+
+    methods = df["method"].tolist()
+    risks = df["abs_es95"].to_numpy(dtype=float)
+    pnls = df["meanpnl_mean"].to_numpy(dtype=float)
+    turnovers = df["turnover_mean"].to_numpy(dtype=float)
+
+    pareto = _pareto_front(list(zip(methods, risks, pnls)))
+
+    plt.style.use("seaborn-v0_8")
+    fig, ax = plt.subplots(figsize=(8, 6))
+    cmap = plt.get_cmap("tab10")
+    min_turn = np.nanmin(turnovers)
+    max_turn = np.nanmax(turnovers)
+    turn_range = max(max_turn - min_turn, 1e-6)
+
+    for idx, method in enumerate(methods):
+        color = cmap(idx % cmap.N)
+        risk = risks[idx]
+        pnl = pnls[idx]
+        turn = turnovers[idx]
+        if math.isnan(risk) or math.isnan(pnl):
+            LOGGER.warning("Skipping method %s due to NaNs", method)
+            continue
+        size = 120 * (1 + (0 if math.isnan(turn) else (turn - min_turn) / turn_range))
+        edgecolor = "black" if method in pareto else color
+        facecolor = color if method in pareto else (*color[:3], 0.5)
+        ax.scatter(risk, pnl, s=size, color=facecolor, edgecolor=edgecolor, linewidths=1.0, alpha=0.85, zorder=3)
+        ax.text(risk, pnl, f" {method}", ha="left", va="center", fontsize=9)
+
+    ax.set_xlabel("|ES95 Mean|")
+    ax.set_ylabel("Mean PnL")
+    ax.set_title("Capital-Efficiency Frontier")
+    ax.grid(alpha=0.3)
+    legend_elements = [
+        plt.Line2D([0], [0], marker="o", color="black", label="Pareto-dominant", markerfacecolor="none", markersize=8),
+        plt.Line2D([0], [0], marker="o", color="gray", label="Non-dominant", markerfacecolor="gray", alpha=0.5, markersize=8),
+    ]
+    ax.legend(handles=legend_elements, loc="best", frameon=False)
+    fig.tight_layout()
+
+    out_path = Path(args.out)
+    _ensure_outdir(out_path)
+    fig.savefig(out_path, dpi=args.dpi)
+    plt.close(fig)
+    LOGGER.info("Saved capital frontier plot to %s", out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plot_cvar_violin.py
+++ b/scripts/plot_cvar_violin.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Create a violin plot showing crisis ES95 dispersion by method."""
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+from pathlib import Path
+from typing import List, Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+LOGGER = logging.getLogger("plot_cvar_violin")
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s | %(message)s")
+
+
+def _t_critical(df: int, confidence: float = 0.95) -> float:
+    if df <= 0:
+        return 0.0
+    alpha = 1.0 - confidence
+    try:  # pragma: no cover - prefer SciPy when available
+        from scipy import stats
+
+        return float(stats.t.ppf(1.0 - alpha / 2.0, df))
+    except Exception:
+        from statistics import NormalDist
+
+        return float(NormalDist().inv_cdf(1.0 - alpha / 2.0))
+
+
+def _confidence_interval(values: Sequence[float]) -> tuple[float, float, float]:
+    cleaned = np.asarray([v for v in values if not math.isnan(v)])
+    if cleaned.size == 0:
+        return math.nan, math.nan, math.nan
+    mean = float(cleaned.mean())
+    if cleaned.size == 1:
+        return mean, mean, mean
+    std = float(cleaned.std(ddof=1))
+    if math.isnan(std):
+        return mean, math.nan, math.nan
+    margin = _t_critical(cleaned.size - 1) * std / math.sqrt(cleaned.size)
+    return mean, mean - margin, mean + margin
+
+
+def _load_csv(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(f"CSV file not found: {path}")
+    return pd.read_csv(path)
+
+
+def _ensure_outdir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scorecard", required=True, help="Path to aggregated scorecard.csv")
+    parser.add_argument("--diagnostics", required=True, help="Path to diagnostics_all.csv")
+    parser.add_argument("--out", required=True, help="Output image path")
+    parser.add_argument("--dpi", type=int, default=200, help="Output figure DPI")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    return parser.parse_args(argv)
+
+
+def _method_order(scorecard: pd.DataFrame, diagnostics: pd.DataFrame) -> List[str]:
+    ordered = []
+    if "method" in scorecard:
+        ordered.extend(list(dict.fromkeys(scorecard["method"].tolist())))
+    diag_methods = list(dict.fromkeys(diagnostics.get("method", pd.Series(dtype=str)).tolist()))
+    for method in diag_methods:
+        if method not in ordered:
+            ordered.append(method)
+    return ordered
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    _setup_logging(args.verbose)
+    scorecard_df = _load_csv(Path(args.scorecard))
+    diagnostics_df = _load_csv(Path(args.diagnostics))
+    if "es95_crisis" not in diagnostics_df.columns:
+        raise KeyError("diagnostics CSV must contain 'es95_crisis' column")
+    diagnostics_df = diagnostics_df.dropna(subset=["es95_crisis"])
+    method_order = _method_order(scorecard_df, diagnostics_df)
+    if not method_order:
+        LOGGER.error("No methods available to plot")
+        return 1
+
+    plt.style.use("seaborn-v0_8")
+    fig, ax = plt.subplots(figsize=(10, 6))
+    cmap = plt.get_cmap("tab10")
+    positions = np.arange(len(method_order))
+
+    for idx, method in enumerate(method_order):
+        subset = diagnostics_df[diagnostics_df["method"] == method]["es95_crisis"].dropna()
+        values = subset.to_numpy(dtype=float)
+        if values.size == 0:
+            LOGGER.warning("Skipping method %s with no crisis ES95 data", method)
+            continue
+        color = cmap(idx % cmap.N)
+        parts = ax.violinplot(
+            values,
+            positions=[positions[idx]],
+            widths=0.8,
+            showmeans=False,
+            showextrema=False,
+            showmedians=False,
+        )
+        for body in parts["bodies"]:
+            body.set_facecolor(color)
+            body.set_edgecolor("black")
+            body.set_alpha(0.35)
+        jitter = (np.random.rand(values.size) - 0.5) * 0.12
+        ax.scatter(
+            np.full(values.size, positions[idx]) + jitter,
+            values,
+            color=color,
+            edgecolor="black",
+            linewidths=0.4,
+            alpha=0.8,
+            zorder=3,
+        )
+        mean, low, high = _confidence_interval(values)
+        if not math.isnan(mean) and not math.isnan(low) and not math.isnan(high):
+            ax.errorbar(
+                positions[idx],
+                mean,
+                yerr=[[mean - low], [high - mean]],
+                fmt="o",
+                color="black",
+                ecolor="black",
+                elinewidth=1.2,
+                capsize=4,
+                markersize=5,
+                zorder=4,
+            )
+            ax.text(
+                positions[idx],
+                mean,
+                f" {mean:.2f}",
+                va="center",
+                ha="left",
+                fontsize=9,
+                color="black",
+            )
+
+    ax.set_xticks(positions)
+    ax.set_xticklabels(method_order, rotation=20, ha="right")
+    ax.set_ylabel("Crisis ES95")
+    ax.set_xlabel("Method")
+    ax.set_title("Crisis ES95 Dispersion by Method")
+    ax.grid(axis="y", alpha=0.3)
+    fig.tight_layout()
+
+    out_path = Path(args.out)
+    _ensure_outdir(out_path)
+    fig.savefig(out_path, dpi=args.dpi)
+    plt.close(fig)
+    LOGGER.info("Saved violin plot to %s", out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plot_ig_vs_cvar.py
+++ b/scripts/plot_ig_vs_cvar.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Scatter plot of IG vs. crisis ES95 with regression fit."""
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+from pathlib import Path
+from typing import Dict, Sequence, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+LOGGER = logging.getLogger("plot_ig_vs_cvar")
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s | %(message)s")
+
+
+def _ensure_outdir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--diagnostics", required=True, help="Path to diagnostics_all.csv")
+    parser.add_argument("--out", required=True, help="Output image path")
+    parser.add_argument("--dpi", type=int, default=200, help="Output figure DPI")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    return parser.parse_args(argv)
+
+
+def _pearsonr(x: np.ndarray, y: np.ndarray) -> Tuple[float, float]:
+    if x.size < 2:
+        return math.nan, math.nan
+    try:  # pragma: no cover - prefer SciPy when available
+        from scipy import stats
+
+        r, p = stats.pearsonr(x, y)
+        return float(r), float(p)
+    except Exception:
+        x_mean = float(x.mean())
+        y_mean = float(y.mean())
+        xm = x - x_mean
+        ym = y - y_mean
+        denom = math.sqrt(float(np.sum(xm ** 2)) * float(np.sum(ym ** 2)))
+        if denom == 0:
+            return math.nan, math.nan
+        r = float(np.sum(xm * ym) / denom)
+        df = x.size - 2
+        if df <= 0:
+            return r, math.nan
+        # two-sided p-value using Student's t-distribution approximation
+        t_stat = abs(r) * math.sqrt(df / max(1e-12, 1 - r * r))
+        try:
+            from statistics import NormalDist
+
+            # Approximate using normal distribution when SciPy is unavailable
+            p = 2 * (1 - NormalDist().cdf(t_stat))
+        except Exception:
+            p = math.nan
+        return r, float(p)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    _setup_logging(args.verbose)
+    diagnostics_path = Path(args.diagnostics)
+    if not diagnostics_path.exists():
+        raise FileNotFoundError(diagnostics_path)
+    df = pd.read_csv(diagnostics_path)
+    if not {"ig", "es95_crisis", "method"}.issubset(df.columns):
+        raise KeyError("diagnostics CSV must contain 'ig', 'es95_crisis', and 'method' columns")
+    df = df.dropna(subset=["ig", "es95_crisis"])
+    if df.empty:
+        LOGGER.error("No diagnostic records with finite IG and ES95 values")
+        return 1
+
+    plt.style.use("seaborn-v0_8")
+    fig, ax = plt.subplots(figsize=(8, 6))
+    cmap = plt.get_cmap("tab10")
+    method_colors: Dict[str, Tuple[float, float, float, float]] = {}
+
+    for idx, method in enumerate(sorted(df["method"].unique())):
+        method_colors[method] = cmap(idx % cmap.N)
+
+    for method, group in df.groupby("method"):
+        color = method_colors.get(method, (0.2, 0.2, 0.2, 1.0))
+        ax.scatter(
+            group["ig"].to_numpy(dtype=float),
+            group["es95_crisis"].to_numpy(dtype=float),
+            label=method,
+            color=color,
+            edgecolor="black",
+            linewidths=0.4,
+            alpha=0.8,
+        )
+
+    x = df["ig"].to_numpy(dtype=float)
+    y = df["es95_crisis"].to_numpy(dtype=float)
+    if x.size >= 2:
+        slope, intercept = np.polyfit(x, y, 1)
+        xs = np.linspace(float(x.min()), float(x.max()), num=200)
+        ax.plot(xs, slope * xs + intercept, color="black", linestyle="--", linewidth=1.5, label="Least-squares fit")
+        r, p = _pearsonr(x, y)
+        caption = f"r = {r:.3f}, p = {p:.3g}" if not math.isnan(r) else "r unavailable"
+        ax.text(0.02, 0.95, caption, transform=ax.transAxes, ha="left", va="top", fontsize=11)
+    else:
+        LOGGER.warning("Not enough points to compute regression")
+
+    ax.set_xlabel("IG (Train ES95 gap)")
+    ax.set_ylabel("Crisis ES95")
+    ax.set_title("IG vs. Crisis ES95")
+    ax.grid(alpha=0.3)
+    ax.legend(frameon=False, loc="best")
+    fig.tight_layout()
+
+    out_path = Path(args.out)
+    _ensure_outdir(out_path)
+    fig.savefig(out_path, dpi=args.dpi)
+    plt.close(fig)
+    LOGGER.info("Saved IG vs ES95 scatter to %s", out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plot_method_schematic.py
+++ b/scripts/plot_method_schematic.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Create a simple schematic comparing ERM, IRM, and HIRM."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+import matplotlib.pyplot as plt
+from matplotlib.patches import FancyBboxPatch
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, help="Output image path")
+    parser.add_argument("--dpi", type=int, default=200, help="Output figure DPI")
+    return parser.parse_args(argv)
+
+
+def _ensure_outdir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _add_box(ax, xy, text, color):
+    box = FancyBboxPatch(
+        xy,
+        width=2.5,
+        height=1.2,
+        boxstyle="round,pad=0.2",
+        linewidth=2,
+        edgecolor=color,
+        facecolor="white",
+    )
+    ax.add_patch(box)
+    ax.text(
+        xy[0] + 1.25,
+        xy[1] + 0.6,
+        text,
+        ha="center",
+        va="center",
+        fontsize=12,
+        color=color,
+        fontweight="bold",
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    plt.style.use("seaborn-v0_8")
+    fig, ax = plt.subplots(figsize=(8, 4))
+    ax.set_axis_off()
+
+    colors = {
+        "ERM": "#1f77b4",
+        "IRM": "#ff7f0e",
+        "HIRM": "#2ca02c",
+    }
+
+    _add_box(ax, (0.5, 1.8), "ERM\nSingle environment loss", colors["ERM"])
+    _add_box(ax, (3.2, 1.8), "IRM\nInvariance penalty", colors["IRM"])
+    _add_box(ax, (5.9, 1.8), "HIRM\nHead-only adaptation", colors["HIRM"])
+
+    arrowprops = dict(arrowstyle="-|>", color="#555555", linewidth=1.6, mutation_scale=15)
+    ax.annotate("", xy=(3.0, 2.4), xytext=(2.8, 2.4), arrowprops=arrowprops)
+    ax.annotate("", xy=(5.7, 2.4), xytext=(5.5, 2.4), arrowprops=arrowprops)
+    ax.text(3.4, 2.25, "Enforce invariance", ha="center", fontsize=10)
+    ax.text(6.5, 2.25, "Freeze backbone\nadapt head", ha="center", fontsize=10)
+
+    fig.tight_layout()
+    out_path = Path(args.out)
+    _ensure_outdir(out_path)
+    fig.savefig(out_path, dpi=args.dpi)
+    plt.close(fig)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add make_scorecard and compute_diagnostics utilities to aggregate phase 2 metrics and diagnostics
- generate plotting scripts for ES95 dispersion, IG vs ES95, capital-efficiency frontier, and method schematic
- export Markdown/LaTeX tables and wire new phase2_scorecard target into the Makefile

## Testing
- python -m compileall invariant-hedging/scripts

------
https://chatgpt.com/codex/tasks/task_e_68e1bb78600c8331ad0a21af5ed8f89a